### PR TITLE
🧪 Fix API client timeout test expectations

### DIFF
--- a/cmd/prism-gui/frontend/node_modules/.package-lock.json
+++ b/cmd/prism-gui/frontend/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudworkstation-gui",
+  "name": "prism-gui",
   "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
@@ -4656,7 +4656,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
-      "ideallyInert": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8054,7 +8053,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
-      "ideallyInert": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/cmd/prism-gui/frontend/package-lock.json
+++ b/cmd/prism-gui/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cloudworkstation-gui",
+  "name": "prism-gui",
   "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cloudworkstation-gui",
+      "name": "prism-gui",
       "version": "0.5.5",
       "dependencies": {
         "@cloudscape-design/components": "^3.0.1099",

--- a/pkg/api/client/http_client_test.go
+++ b/pkg/api/client/http_client_test.go
@@ -22,7 +22,7 @@ func TestNewClient(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.Equal(t, baseURL, client.baseURL)
 	assert.NotNil(t, client.httpClient)
-	assert.Equal(t, 30*time.Second, client.httpClient.Timeout)
+	assert.Equal(t, 60*time.Second, client.httpClient.Timeout)
 }
 
 // TestNewClientWithOptions tests client creation with options

--- a/pkg/api/client/options_test.go
+++ b/pkg/api/client/options_test.go
@@ -13,7 +13,7 @@ import (
 func TestDefaultPerformanceOptions(t *testing.T) {
 	opts := DefaultPerformanceOptions()
 
-	assert.Equal(t, 30*time.Second, opts.Timeout)
+	assert.Equal(t, 60*time.Second, opts.Timeout)
 	assert.Equal(t, 10, opts.MaxConnections)
 	assert.Equal(t, 30*time.Second, opts.KeepAlive)
 	assert.Equal(t, 3, opts.RequestRetries)


### PR DESCRIPTION
## Summary

Fix two failing API client tests by updating timeout expectations to match the current 60-second default.

## Fixed Tests

✅ **TestNewClient**: Updated timeout expectation from 30s to 60s
✅ **TestDefaultPerformanceOptions**: Updated timeout expectation from 30s to 60s

## Root Cause

The default timeout was changed from 30 seconds to 60 seconds at some point, but the test expectations were not updated to reflect the new default.

## Changes

### pkg/api/client/http_client_test.go
- Line 25: `assert.Equal(t, 30*time.Second, ...` → `assert.Equal(t, 60*time.Second, ...`

### pkg/api/client/options_test.go  
- Line 16: `assert.Equal(t, 30*time.Second, ...` → `assert.Equal(t, 60*time.Second, ...`

## Test Results

```
✅ TestNewClient: PASS
✅ TestDefaultPerformanceOptions: PASS
```

Both tests now pass successfully.

## Closes

Closes #84