### PR TITLE
feat(idle): Implement idle policy persistence and GUI management (Issue #288)

### DIFF
--- a/cmd/prism-gui/frontend/src/App.tsx
+++ b/cmd/prism-gui/frontend/src/App.tsx
@@ -1711,6 +1711,36 @@ class SafePrismAPI {
     }
   }
 
+  // Per-instance Idle Policy APIs (Issue #288)
+  async getInstanceIdlePolicies(instanceName: string): Promise<IdlePolicy[]> {
+    try {
+      const data = await this.safeRequest(`/api/v1/instances/${instanceName}/idle/policies`);
+      if (!data || !Array.isArray(data)) return [];
+      return (data as Record<string, unknown>[]).map((p) => ({
+        id: (p.id as string) || '',
+        name: (p.name as string) || (p.Name as string) || '',
+        idle_minutes: (p.idle_minutes as number) || 0,
+        action: ((p.action as string) || 'notify') as 'hibernate' | 'stop' | 'notify',
+        cpu_threshold: (p.cpu_threshold as number) || 10,
+        memory_threshold: (p.memory_threshold as number) || 10,
+        network_threshold: (p.network_threshold as number) || 1,
+        description: (p.description as string) || '',
+        enabled: p.enabled !== undefined ? (p.enabled as boolean) : true
+      }));
+    } catch (error) {
+      logger.error(`Failed to fetch idle policies for ${instanceName}:`, error);
+      return [];
+    }
+  }
+
+  async applyIdlePolicy(instanceName: string, policyId: string): Promise<void> {
+    await this.safeRequest(`/api/v1/instances/${instanceName}/idle/policies/${policyId}`, 'PUT');
+  }
+
+  async removeIdlePolicy(instanceName: string, policyId: string): Promise<void> {
+    await this.safeRequest(`/api/v1/instances/${instanceName}/idle/policies/${policyId}`, 'DELETE');
+  }
+
   // Profile Management APIs
   async getProfiles(): Promise<any[]> {
     try {
@@ -1847,6 +1877,9 @@ export default function PrismApp() {
   // Hibernate confirmation modal state
   const [hibernateModalVisible, setHibernateModalVisible] = useState(false);
   const [hibernateModalInstance, setHibernateModalInstance] = useState<Instance | null>(null);
+
+  // Idle policy modal state (Issue #288)
+  const [idlePolicyModalInstance, setIdlePolicyModalInstance] = useState<string | null>(null);
 
   // Onboarding wizard state
   const [onboardingVisible, setOnboardingVisible] = useState(false);
@@ -3256,6 +3289,10 @@ export default function PrismApp() {
             loading: false
           }));
           return; // Don't continue with normal flow
+        case 'manage-idle-policy':
+          setState(prev => ({ ...prev, loading: false }));
+          setIdlePolicyModalInstance(instance.name);
+          return;
         case 'delete':
           // Show confirmation modal instead of deleting immediately
           setState(prev => ({ ...prev, loading: false }));
@@ -3701,6 +3738,7 @@ export default function PrismApp() {
                       { text: 'Start', id: 'start', disabled: item.state === 'running' },
                       { text: 'Hibernate', id: 'hibernate', disabled: item.state !== 'running' },
                       { text: 'Resume', id: 'resume', disabled: item.state !== 'stopped' && item.state !== 'hibernated' },
+                      { text: 'Manage Idle Policy', id: 'manage-idle-policy' },
                       { text: 'Delete', id: 'delete', disabled: item.state === 'running' || item.state === 'pending' }
                     ]}
                     onItemClick={({ detail }) => {
@@ -10328,6 +10366,176 @@ export default function PrismApp() {
     );
   };
 
+  // Idle Policy Modal — apply/remove idle policies on a specific instance (Issue #288)
+  const IdlePolicyModal = () => {
+    const [availablePolicies, setAvailablePolicies] = useState<IdlePolicy[]>([]);
+    const [appliedPolicies, setAppliedPolicies] = useState<IdlePolicy[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+      if (!idlePolicyModalInstance) return;
+      setLoading(true);
+      Promise.all([
+        api.getIdlePolicies(),
+        api.getInstanceIdlePolicies(idlePolicyModalInstance)
+      ]).then(([all, applied]) => {
+        setAvailablePolicies(all);
+        setAppliedPolicies(applied);
+      }).catch(err => {
+        logger.error('Failed to load idle policies:', err);
+      }).finally(() => setLoading(false));
+    }, [idlePolicyModalInstance]);
+
+    if (!idlePolicyModalInstance) return null;
+
+    const appliedIds = new Set(appliedPolicies.map(p => p.id));
+
+    const handleApply = async (policyId: string, policyName: string) => {
+      setIdlePolicyModalInstance(null);
+      setState(prev => ({
+        ...prev,
+        notifications: [...prev.notifications, {
+          type: 'info',
+          header: 'Applying Idle Policy',
+          content: `Applying "${policyName}" to ${idlePolicyModalInstance}...`,
+          dismissible: true,
+          id: Date.now().toString()
+        }]
+      }));
+      try {
+        await api.applyIdlePolicy(idlePolicyModalInstance, policyId);
+        setState(prev => ({
+          ...prev,
+          notifications: [...prev.notifications, {
+            type: 'success',
+            header: 'Idle Policy Applied',
+            content: `"${policyName}" applied to ${idlePolicyModalInstance}`,
+            dismissible: true,
+            id: Date.now().toString()
+          }]
+        }));
+      } catch (error) {
+        setState(prev => ({
+          ...prev,
+          notifications: [...prev.notifications, {
+            type: 'error',
+            header: 'Failed to Apply Policy',
+            content: `${error instanceof Error ? error.message : String(error)}`,
+            dismissible: true,
+            id: Date.now().toString()
+          }]
+        }));
+      }
+    };
+
+    const handleRemove = async (policyId: string, policyName: string) => {
+      setIdlePolicyModalInstance(null);
+      setState(prev => ({
+        ...prev,
+        notifications: [...prev.notifications, {
+          type: 'info',
+          header: 'Removing Idle Policy',
+          content: `Removing "${policyName}" from ${idlePolicyModalInstance}...`,
+          dismissible: true,
+          id: Date.now().toString()
+        }]
+      }));
+      try {
+        await api.removeIdlePolicy(idlePolicyModalInstance, policyId);
+        setState(prev => ({
+          ...prev,
+          notifications: [...prev.notifications, {
+            type: 'success',
+            header: 'Idle Policy Removed',
+            content: `"${policyName}" removed from ${idlePolicyModalInstance}`,
+            dismissible: true,
+            id: Date.now().toString()
+          }]
+        }));
+      } catch (error) {
+        setState(prev => ({
+          ...prev,
+          notifications: [...prev.notifications, {
+            type: 'error',
+            header: 'Failed to Remove Policy',
+            content: `${error instanceof Error ? error.message : String(error)}`,
+            dismissible: true,
+            id: Date.now().toString()
+          }]
+        }));
+      }
+    };
+
+    return (
+      <Modal
+        visible={!!idlePolicyModalInstance}
+        onDismiss={() => setIdlePolicyModalInstance(null)}
+        header={`Manage Idle Policy — ${idlePolicyModalInstance}`}
+        size="medium"
+        data-testid="idle-policy-modal"
+        footer={
+          <Box float="right">
+            <Button variant="link" onClick={() => setIdlePolicyModalInstance(null)}>Close</Button>
+          </Box>
+        }
+      >
+        <SpaceBetween size="m">
+          {appliedPolicies.length > 0 && (
+            <Alert type="info" header="Currently Applied">
+              {appliedPolicies.map(p => (
+                <SpaceBetween key={p.id} direction="horizontal" size="xs">
+                  <Box variant="span"><strong>{p.name}</strong> — {p.description}</Box>
+                  <Button
+                    variant="link"
+                    onClick={() => handleRemove(p.id, p.name)}
+                    data-testid={`remove-idle-policy-${p.id}`}
+                  >
+                    Remove
+                  </Button>
+                </SpaceBetween>
+              ))}
+            </Alert>
+          )}
+          {loading ? (
+            <Box textAlign="center"><Spinner /></Box>
+          ) : (
+            <Table
+              data-testid="idle-policy-templates-table"
+              columnDefinitions={[
+                { id: 'name', header: 'Policy', cell: (item: IdlePolicy) => item.name },
+                { id: 'description', header: 'Description', cell: (item: IdlePolicy) => item.description || '' },
+                { id: 'savings', header: 'Est. Savings', cell: (item: IdlePolicy) => `${(item as unknown as Record<string, unknown>).estimated_savings_percent ?? '—'}%` },
+                {
+                  id: 'action',
+                  header: '',
+                  cell: (item: IdlePolicy) => appliedIds.has(item.id) ? (
+                    <Button
+                      variant="link"
+                      onClick={() => handleRemove(item.id, item.name)}
+                      data-testid={`remove-idle-policy-${item.id}`}
+                    >
+                      Remove
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="primary"
+                      onClick={() => handleApply(item.id, item.name)}
+                      data-testid={`apply-idle-policy-${item.id}`}
+                    >
+                      Apply
+                    </Button>
+                  )
+                }
+              ]}
+              items={availablePolicies}
+              empty={<Box textAlign="center">No idle policy templates available</Box>}
+            />
+          )}
+        </SpaceBetween>
+      </Modal>
+    );
+  };
+
   const HibernateConfirmationModal = () => {
     if (!hibernateModalInstance) return null;
 
@@ -11943,6 +12151,7 @@ export default function PrismApp() {
       <RestoreBackupModal />
       <DeleteConfirmationModal />
       <HibernateConfirmationModal />
+      <IdlePolicyModal />
       <OnboardingWizard />
       <QuickStartWizard />
       <CreateProjectModal />

--- a/pkg/daemon/idle_handlers.go
+++ b/pkg/daemon/idle_handlers.go
@@ -18,7 +18,44 @@ func (s *Server) RegisterIdleRoutes(mux *http.ServeMux, applyMiddleware func(htt
 	mux.HandleFunc("/api/v1/idle/policies/apply", applyMiddleware(s.handleIdlePolicyApply)) // Register specific route before wildcard
 	mux.HandleFunc("/api/v1/idle/policies/", applyMiddleware(s.handleIdlePolicyOperations)) // Wildcard route last
 	mux.HandleFunc("/api/v1/idle/schedules", applyMiddleware(s.handleIdleSchedules))
+	mux.HandleFunc("/api/v1/idle/schedules/", applyMiddleware(s.handleIdleScheduleByID)) // Per-schedule operations (Issue #288)
 	mux.HandleFunc("/api/v1/idle/savings", applyMiddleware(s.handleIdleSavings))
+}
+
+// saveIdleSchedules persists current scheduler state to disk (best-effort, Issue #288)
+func (s *Server) saveIdleSchedules() {
+	if s.idleScheduler == nil || s.stateManager == nil {
+		return
+	}
+	schedules := s.idleScheduler.ListSchedules()
+	data, err := json.Marshal(schedules)
+	if err != nil {
+		return
+	}
+	state, err := s.stateManager.LoadState()
+	if err != nil {
+		return
+	}
+	state.IdleSchedules = json.RawMessage(data)
+	_ = s.stateManager.SaveState(state)
+}
+
+// loadIdleSchedules hydrates the scheduler from persisted state on startup (Issue #288)
+func (s *Server) loadIdleSchedules() {
+	if s.idleScheduler == nil || s.stateManager == nil {
+		return
+	}
+	state, err := s.stateManager.LoadState()
+	if err != nil || len(state.IdleSchedules) == 0 {
+		return
+	}
+	var schedules []*idle.Schedule
+	if err := json.Unmarshal(state.IdleSchedules, &schedules); err != nil {
+		return
+	}
+	for _, schedule := range schedules {
+		_ = s.idleScheduler.AddSchedule(schedule)
+	}
 }
 
 // handleIdlePolicies handles /api/v1/idle/policies
@@ -79,6 +116,32 @@ func (s *Server) handleIdleSavings(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		s.getIdleSavingsReport(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleIdleScheduleByID handles /api/v1/idle/schedules/{id} (Issue #288)
+func (s *Server) handleIdleScheduleByID(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/v1/idle/schedules/")
+	if id == "" {
+		http.Error(w, "Schedule ID required", http.StatusBadRequest)
+		return
+	}
+
+	if s.idleScheduler == nil {
+		http.Error(w, "Scheduler not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	switch r.Method {
+	case "DELETE":
+		if err := s.idleScheduler.RemoveSchedule(id); err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		s.saveIdleSchedules()
+		w.WriteHeader(http.StatusNoContent)
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -368,6 +431,9 @@ func (s *Server) applyIdlePolicyToInstance(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// Persist schedules after applying policy (Issue #288)
+	s.saveIdleSchedules()
+
 	response := map[string]string{
 		"status":  "success",
 		"message": fmt.Sprintf("Successfully applied idle policy %s to instance %s", policyID, instanceName),
@@ -407,6 +473,9 @@ func (s *Server) removeIdlePolicyFromInstance(w http.ResponseWriter, r *http.Req
 		http.Error(w, fmt.Sprintf("No schedules found for policy %s on instance %s", policyID, instanceName), http.StatusNotFound)
 		return
 	}
+
+	// Persist schedules after removing policy (Issue #288)
+	s.saveIdleSchedules()
 
 	response := map[string]string{
 		"status":  "success",

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -405,6 +405,12 @@ func NewServer(port string) (*Server, error) {
 		testMode:            os.Getenv("PRISM_TEST_MODE") == "true", // E2E test mode - skip AWS operations
 	}
 
+	// Load persisted idle schedules into scheduler (Issue #288)
+	if server.idleScheduler != nil {
+		server.loadIdleSchedules()
+		logger.Info("Idle schedules loaded from persisted state")
+	}
+
 	// Print reduced mode banner if AWS credentials unavailable (Issue #356)
 	if reducedMode {
 		logger.Warn("Starting in reduced functionality mode")

--- a/pkg/idle/scheduler.go
+++ b/pkg/idle/scheduler.go
@@ -455,6 +455,36 @@ func (s *Scheduler) DeleteSchedule(id string) error {
 	return nil
 }
 
+// RemoveSchedule removes a schedule and cleans up all instance associations (Issue #288)
+func (s *Scheduler) RemoveSchedule(scheduleID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.schedules[scheduleID]; !exists {
+		return fmt.Errorf("schedule not found: %s", scheduleID)
+	}
+
+	delete(s.schedules, scheduleID)
+	delete(s.active, scheduleID)
+
+	// Clean up all instance->schedule mappings that reference this schedule
+	for name, ids := range s.instanceSchedules {
+		filtered := ids[:0]
+		for _, id := range ids {
+			if id != scheduleID {
+				filtered = append(filtered, id)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(s.instanceSchedules, name)
+		} else {
+			s.instanceSchedules[name] = filtered
+		}
+	}
+
+	return nil
+}
+
 // GetSchedule retrieves a schedule
 func (s *Scheduler) GetSchedule(id string) (*Schedule, error) {
 	s.mu.RLock()

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Config manages application configuration
 type Config struct {
@@ -16,6 +19,7 @@ type State struct {
 	Instances      map[string]Instance      `json:"instances"`
 	StorageVolumes map[string]StorageVolume `json:"storage_volumes"`
 	Config         Config                   `json:"config"`
+	IdleSchedules  json.RawMessage          `json:"idle_schedules,omitempty"` // Persisted idle schedules (Issue #288)
 }
 
 // CurrentStateVersion is the current version of the state file format


### PR DESCRIPTION
## Summary

Closes #288 — Idle policy backend execution: make hibernation schedules actually run.

The idle system had a complete execution engine but schedules were never persisted — they evaporated on daemon restart, and could not be managed from the GUI. This PR wires everything together.

- **Persist schedules**: Applied policies are saved to `~/.prism/state.json` (`idle_schedules` field) and reloaded into the scheduler on every daemon startup
- **DELETE endpoint**: New `DELETE /api/v1/idle/schedules/{id}` for removing individual schedules; cleans up `instanceSchedules` mappings correctly (existing `DeleteSchedule` was missing this)
- **GUI management**: "Manage Idle Policy" action in the instance dropdown opens a modal listing all 6 built-in policy templates with Apply/Remove buttons; fire-and-forget pattern closes modal immediately

## Changes

| File | Change |
|------|--------|
| `pkg/types/config.go` | Add `IdleSchedules json.RawMessage` to `State` struct |
| `pkg/idle/scheduler.go` | Add `RemoveSchedule()` with full `instanceSchedules` cleanup |
| `pkg/daemon/idle_handlers.go` | `saveIdleSchedules`, `loadIdleSchedules`, `handleIdleScheduleByID`; call save after mutations |
| `pkg/daemon/server.go` | Call `loadIdleSchedules()` at end of `NewServer()` |
| `cmd/prism-gui/frontend/src/App.tsx` | 3 SafePrismAPI methods + "Manage Idle Policy" dropdown + `IdlePolicyModal` |

## Verification

Smoke-tested end-to-end:
1. Apply "balanced" policy → schedule created ✅
2. Daemon restart → schedule persists with same ID ✅
3. `DELETE /api/v1/idle/schedules/{id}` → 204, schedule removed ✅
4. List after delete → empty `[]` ✅

> **Note**: The code on this branch is already on `main` (commit `1d8e3ce46`) — this PR is for review/tracking. Please close rather than merge to avoid a duplicate commit.