### PR TITLE
fix(templates): generate RStudio Server password for researcher user

### DIFF
--- a/docs/user-guides/R_GETTING_STARTED.md
+++ b/docs/user-guides/R_GETTING_STARTED.md
@@ -54,16 +54,32 @@ output — it takes about 8 minutes. When it completes you'll see:
 
 ### Connect
 
-Open your browser to `http://<public-ip>:8787`. Log in with:
-
-- **Username**: `researcher`
-- **Password**: the system password shown in `prism workspace connect my-analysis` output (or set during init)
-
-You can also SSH directly:
+**SSH** (works immediately — uses your SSH key):
 
 ```bash
 prism workspace connect my-analysis          # opens SSH terminal
 ```
+
+**RStudio Server** requires a system password for the `researcher` user. Templates that
+include RStudio generate a random password during provisioning and print it in the launch
+log. Look for lines like:
+
+```
+=============================================
+  RStudio Server Login Credentials
+  Username: researcher
+  Password: <random-password>
+=============================================
+```
+
+If you missed the password or need to reset it, SSH in and run:
+
+```bash
+sudo passwd researcher
+```
+
+Then open `http://<public-ip>:8787` and log in with username `researcher` and the password
+you set.
 
 ### Verify your environment
 
@@ -444,7 +460,7 @@ prism ami delete <ami-id>                                  # remove AMI
 | R Research Publishing Stack | `http://<ip>:8787` (RStudio) / `http://<ip>:8888` (Jupyter) |
 | R Shiny Server | `http://<ip>:3838` |
 
-**RStudio login**: Username `researcher`, system password
+**RStudio login**: Username `researcher`, password from provisioning log (or reset via `sudo passwd researcher` over SSH)
 
 ### Posit Package Manager URL
 

--- a/templates/community/r-publishing-stack.yml
+++ b/templates/community/r-publishing-stack.yml
@@ -248,6 +248,17 @@ post_install: |
   git lfs install --system
   echo "✅ Git LFS installed"
 
+  # Set password for researcher user (required for RStudio Server PAM authentication)
+  RESEARCHER_PASSWORD=$(openssl rand -base64 12)
+  echo "researcher:${RESEARCHER_PASSWORD}" | chpasswd
+  echo ""
+  echo "============================================="
+  echo "  RStudio Server Login Credentials"
+  echo "  Username: researcher"
+  echo "  Password: ${RESEARCHER_PASSWORD}"
+  echo "============================================="
+  echo ""
+
   # Create additional directories
   mkdir -p /home/researcher/{notebooks,documents}
   chown -R researcher:researcher /home/researcher

--- a/templates/community/r-research-full-stack.yml
+++ b/templates/community/r-research-full-stack.yml
@@ -329,6 +329,17 @@ post_install: |
   # Restart RStudio Server with new configuration
   systemctl restart rstudio-server
 
+  # Set password for researcher user (required for RStudio Server PAM authentication)
+  RESEARCHER_PASSWORD=$(openssl rand -base64 12)
+  echo "researcher:${RESEARCHER_PASSWORD}" | chpasswd
+  echo ""
+  echo "============================================="
+  echo "  RStudio Server Login Credentials"
+  echo "  Username: researcher"
+  echo "  Password: ${RESEARCHER_PASSWORD}"
+  echo "============================================="
+  echo ""
+
   # Create researcher user home directory structure
   mkdir -p /home/researcher/{projects,data,notebooks,documents,scripts}
   chown -R researcher:researcher /home/researcher

--- a/templates/community/r-rstudio-server.yml
+++ b/templates/community/r-rstudio-server.yml
@@ -132,6 +132,18 @@ post_install: |
     systemctl status rstudio-server
   fi
 
+  # Set password for researcher user (required for RStudio Server PAM authentication)
+  # SSH key auth handles terminal access, but RStudio Server needs a system password
+  RESEARCHER_PASSWORD=$(openssl rand -base64 12)
+  echo "researcher:${RESEARCHER_PASSWORD}" | chpasswd
+  echo ""
+  echo "============================================="
+  echo "  RStudio Server Login Credentials"
+  echo "  Username: researcher"
+  echo "  Password: ${RESEARCHER_PASSWORD}"
+  echo "============================================="
+  echo ""
+
   # Update welcome message
   echo "Updating welcome message..."
   cat > /home/researcher/WELCOME.txt <<'WELCOME_END'
@@ -140,7 +152,7 @@ post_install: |
   RStudio Server (Web IDE):
     URL: http://YOUR_IP:8787
     Username: researcher
-    Password: Your system password
+    Password: from provisioning log (reset via: sudo passwd researcher)
 
   R Version: Inherited from R Base layer
   Packages: tidyverse, rmarkdown, knitr, devtools
@@ -168,7 +180,8 @@ post_install: |
   echo ""
   INSTANCE_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || hostname -I | awk '{print $1}')
   echo "🖥️  RStudio Server: http://${INSTANCE_IP}:8787"
-  echo "👤 Login with username and password"
+  echo "👤 Login: username 'researcher', password above"
+  echo "   To reset: sudo passwd researcher (via SSH)"
   echo ""
 
 # Idle detection - check both R and RStudio processes


### PR DESCRIPTION
## Summary

- RStudio Server templates create a `researcher` user via `useradd` but never set a password. SSH works (key-based), but RStudio Server uses PAM authentication — so users cannot log into the web IDE at `:8787`.
- Generate a random password with `openssl rand` during provisioning, set it via `chpasswd`, and print credentials in the provisioning log.
- Fix the R Getting Started guide, which incorrectly claimed `prism workspace connect` shows a password.

Templates fixed: `r-rstudio-server`, `r-research-full-stack`, `r-publishing-stack`. The `ultimate-research-workstation` template already handled this correctly.

## Test plan

- [ ] Launch an instance with `r-rstudio-server` template and verify the password appears in the provisioning log
- [ ] Log into RStudio Server at `:8787` using the printed credentials
- [ ] Verify `sudo passwd researcher` resets the password successfully
- [ ] Repeat for `r-research-full-stack` and `r-publishing-stack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)