### PR TITLE
fix: gzip-compress EC2 user data to avoid 16 KB limit

### DIFF
--- a/pkg/aws/manager.go
+++ b/pkg/aws/manager.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
@@ -322,7 +324,10 @@ type UserDataProcessor struct {
 	region  string
 }
 
-// ProcessUserData configures and encodes user data for instance launch
+// ProcessUserData configures and encodes user data for instance launch.
+// The script is gzip-compressed before base64-encoding so that large
+// cloud-init scripts stay within EC2's 16 KB (25 600 bytes encoded) limit.
+// cloud-init transparently detects and decompresses gzipped user data.
 func (p *UserDataProcessor) ProcessUserData(template *ctypes.RuntimeTemplate, req ctypes.LaunchRequest) string {
 	userData := template.UserData
 	userData = p.manager.processIdleDetectionConfig(userData, template)
@@ -334,7 +339,31 @@ func (p *UserDataProcessor) ProcessUserData(template *ctypes.RuntimeTemplate, re
 		}
 	}
 
-	return base64.StdEncoding.EncodeToString([]byte(userData))
+	// Gzip-compress the script. cloud-init detects the gzip magic bytes
+	// and decompresses automatically, so this is transparent to templates.
+	// Compression typically achieves 3-5x reduction on shell scripts,
+	// raising the effective user data limit from ~19 KB to ~60 KB.
+	compressed, err := gzipBytes([]byte(userData))
+	if err != nil {
+		// Fall back to uncompressed if gzip fails (should not happen)
+		log.Printf("Warning: gzip compression of user data failed, using uncompressed: %v", err)
+		return base64.StdEncoding.EncodeToString([]byte(userData))
+	}
+
+	return base64.StdEncoding.EncodeToString(compressed)
+}
+
+// gzipBytes compresses data using gzip and returns the compressed bytes.
+func gzipBytes(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(data); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // NetworkingResolver resolves VPC, subnet, and security group (Single Responsibility - SOLID)

--- a/pkg/aws/userdata_test.go
+++ b/pkg/aws/userdata_test.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestGzipBytes(t *testing.T) {
+	input := []byte("#!/bin/bash\necho hello world\n")
+	compressed, err := gzipBytes(input)
+	if err != nil {
+		t.Fatalf("gzipBytes failed: %v", err)
+	}
+
+	// Verify gzip magic bytes (1f 8b)
+	if len(compressed) < 2 || compressed[0] != 0x1f || compressed[1] != 0x8b {
+		t.Fatal("compressed output does not have gzip magic bytes")
+	}
+
+	// Verify round-trip decompression
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatalf("gzip.NewReader failed: %v", err)
+	}
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading decompressed data failed: %v", err)
+	}
+	reader.Close()
+
+	if !bytes.Equal(decompressed, input) {
+		t.Fatalf("round-trip mismatch:\n  got:  %q\n  want: %q", decompressed, input)
+	}
+}
+
+func TestGzipBytesCompressesLargeScript(t *testing.T) {
+	// Simulate a large cloud-init script (~20 KB of repetitive shell commands)
+	var sb strings.Builder
+	sb.WriteString("#!/bin/bash\nset -e\n")
+	for i := 0; i < 500; i++ {
+		sb.WriteString("apt-get install -y some-package-name-that-is-reasonably-long\n")
+	}
+	input := []byte(sb.String())
+
+	compressed, err := gzipBytes(input)
+	if err != nil {
+		t.Fatalf("gzipBytes failed: %v", err)
+	}
+
+	// Shell scripts with repetitive text should compress well (at least 3x)
+	ratio := float64(len(input)) / float64(len(compressed))
+	if ratio < 3.0 {
+		t.Errorf("compression ratio %.1fx is worse than expected (want >= 3x); raw=%d compressed=%d",
+			ratio, len(input), len(compressed))
+	}
+
+	// After base64 encoding, result should fit in EC2's 25600 byte limit
+	encoded := base64.StdEncoding.EncodeToString(compressed)
+	if len(input) > 19200 && len(encoded) < 25600 {
+		t.Logf("Success: %d byte script -> %d bytes compressed -> %d bytes base64 (fits EC2 limit)",
+			len(input), len(compressed), len(encoded))
+	}
+}


### PR DESCRIPTION
## Summary

- Gzip-compress cloud-init user data before base64-encoding in `ProcessUserData`
- cloud-init detects gzip magic bytes and decompresses transparently — no template changes needed
- Falls back to uncompressed encoding if gzip fails (defensive only)
- Raises the effective user data limit from ~19 KB to ~60 KB for typical shell scripts

## Context

Templates with large `post_install` scripts (e.g., inline editor configs, helper scripts, extensive package lists) can exceed EC2's 16 KB raw / 25,600 byte base64-encoded user data limit, causing launch failures:

```
InvalidParameterValue: Encoded User data is limited to 25600 bytes
```

This is a one-line behavioral change (gzip before base64) that is invisible to all existing templates and the rest of the launch pipeline.

## Test plan

- [x] New unit tests in `pkg/aws/userdata_test.go` verify gzip round-trip and compression ratio
- [x] All existing `pkg/aws` tests pass
- [x] Full build (`prism`, `prismd`) compiles cleanly
- [ ] Manual launch test with a large template (>19 KB user data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)