### PR TITLE
fix(daemon): prefer live instance when refreshing state with duplicate names

### DIFF
--- a/pkg/daemon/instance_handlers.go
+++ b/pkg/daemon/instance_handlers.go
@@ -80,8 +80,22 @@ func (s *Server) handleListInstances(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Update local state with fresh AWS data
+		// Update local state with fresh AWS data.
+		// When multiple instances share the same name (e.g. one running, one
+		// terminated), prefer the non-terminated instance so that connect and
+		// other operations resolve to the live instance.
+		bestByName := make(map[string]types.Instance)
 		for _, instance := range instances {
+			if existing, ok := bestByName[instance.Name]; ok {
+				// Keep the non-terminated instance
+				if existing.State == "terminated" || existing.State == "terminating" {
+					bestByName[instance.Name] = instance
+				}
+			} else {
+				bestByName[instance.Name] = instance
+			}
+		}
+		for _, instance := range bestByName {
 			_ = s.stateManager.SaveInstance(instance)
 		}
 	} else {


### PR DESCRIPTION
## Summary
- When two instances share the same name (e.g. one running, one terminated after delete+relaunch), `list --refresh` saved both to local state by name with last-write-wins
- If the terminated instance was written last, `connect` and other name-based lookups resolved to the dead instance and failed with "no public IP address"
- Deduplicates by name before saving, preferring non-terminated instances over terminated/terminating ones

## Test plan
- [ ] Launch instance A, terminate it, launch instance B with same name
- [ ] Run `prism workspace list --refresh`
- [ ] Verify `prism workspace connect <name>` resolves to instance B (the running one)
- [ ] Verify local state (`~/.prism/state.json`) has the running instance's ID, not the terminated one's

🤖 Generated with [Claude Code](https://claude.com/claude-code)