### PR TITLE
fix: correct legacy 'prism launch/list/connect' to 'prism workspace ...'

### DIFF
--- a/cmd/prism/main.go
+++ b/cmd/prism/main.go
@@ -6,10 +6,10 @@
 //
 // Core Commands:
 //
-//	prism launch template-name instance-name  # Launch new research environment
-//	prism list                                # Show running instances and costs
-//	prism connect instance-name               # Get connection information
-//	prism stop/start instance-name            # Manage instance lifecycle
+//	prism workspace launch template-name instance-name  # Launch new research environment
+//	prism workspace list                                # Show running instances and costs
+//	prism workspace connect instance-name               # Get connection information
+//	prism workspace stop/start instance-name            # Manage instance lifecycle
 //
 // Storage Commands:
 //
@@ -18,10 +18,10 @@
 //
 // Examples:
 //
-//	prism launch r-research my-analysis       # Launch R environment
-//	prism launch python-ml gpu-training --size GPU-L  # Launch ML environment
-//	prism list                                # Show all instances
-//	prism connect my-analysis                 # Get SSH/web URLs
+//	prism workspace launch r-research my-analysis       # Launch R environment
+//	prism workspace launch python-ml gpu-training --size GPU-L  # Launch ML environment
+//	prism workspace list                                # Show all instances
+//	prism workspace connect my-analysis                 # Get SSH/web URLs
 //
 // The CLI implements Prism's "Default to Success" principle -
 // every command works out of the box with smart defaults while providing

--- a/internal/cli/about.go
+++ b/internal/cli/about.go
@@ -101,7 +101,7 @@ func runAbout() {
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	fmt.Println("   prism --help             Show all available commands")
 	fmt.Println("   prism templates          List available templates")
-	fmt.Println("   prism launch <template> <name>  Launch a new workstation")
+	fmt.Println("   prism workspace launch <template> <name>  Launch a new workstation")
 	fmt.Println("   prism tui                Launch terminal interface")
 	fmt.Println("   prism gui                Launch graphical interface")
 	fmt.Println()

--- a/internal/cli/ami.go
+++ b/internal/cli/ami.go
@@ -894,7 +894,7 @@ func (s *AMISaveBuilderService) displaySaveResults(result *ami.BuildResult, temp
 	}
 
 	fmt.Printf("\n✨ Template '%s' is now available for launching new workspaces:\n", templateName)
-	fmt.Printf("   prism launch %s my-new-instance\n", templateName)
+	fmt.Printf("   prism workspace launch %s my-new-instance\n", templateName)
 
 	return nil
 }

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -270,7 +270,7 @@ func (a *App) TUI(_ []string) error {
 // Launch handles the launch command
 func (a *App) Launch(args []string) error {
 	if len(args) < 2 {
-		return NewUsageError("prism launch <template> <name>", "prism launch python-ml my-workstation")
+		return NewUsageError("prism workspace launch <template> <name>", "prism workspace launch python-ml my-workstation")
 	}
 
 	template := args[0]
@@ -594,8 +594,8 @@ func (a *App) monitorLaunchWithEnhancedProgress(reporter *ProgressReporter, temp
 		if !wait && elapsed > maxDuration {
 			fmt.Printf("⚠️  Launch monitoring timeout (%s). Workspace may still be setting up.\n",
 				reporter.FormatDuration(maxDuration))
-			fmt.Printf("💡 Check status with: prism list\n")
-			fmt.Printf("💡 Try connecting: prism connect %s\n", reporter.instanceName)
+			fmt.Printf("💡 Check status with: prism workspace list\n")
+			fmt.Printf("💡 Try connecting: prism workspace connect %s\n", reporter.instanceName)
 			return nil
 		}
 
@@ -608,7 +608,7 @@ func (a *App) monitorLaunchWithEnhancedProgress(reporter *ProgressReporter, temp
 			} else {
 				// After 30 seconds, show as potential issue
 				fmt.Printf("⚠️  Unable to get instance status after %s\n", reporter.FormatDuration(elapsed))
-				fmt.Printf("💡 Workspace may still be launching. Check with: prism list\n")
+				fmt.Printf("💡 Workspace may still be launching. Check with: prism workspace list\n")
 			}
 			time.Sleep(5 * time.Second)
 			continue
@@ -696,7 +696,7 @@ func (h *RunningStateHandler) Handle(state string, elapsed int, instanceName str
 		_, connErr := h.apiClient.ConnectInstance(h.ctx, instanceName)
 		if connErr == nil {
 			fmt.Printf("✅ Setup complete! Workspace ready.\n")
-			fmt.Printf("🔗 Connect: prism connect %s\n", instanceName)
+			fmt.Printf("🔗 Connect: prism workspace connect %s\n", instanceName)
 			return false, nil
 		}
 	}
@@ -897,7 +897,7 @@ func printRunningCostSummary(instances []types.Instance) {
 		fmt.Printf("   Total accumulated:  $%.4f (since launch)\n", totalCurrent)
 		fmt.Printf("   Effective rate:     $%.4f/hr (actual usage)\n", totalEffective)
 		fmt.Printf("   Estimated daily:    $%.2f (at current rate)\n", totalEffective*24)
-		fmt.Printf("\n💡 Tip: Use 'prism list cost' for detailed cost breakdown with savings analysis\n")
+		fmt.Printf("\n💡 Tip: Use 'prism workspace list cost' for detailed cost breakdown with savings analysis\n")
 	}
 }
 
@@ -1020,7 +1020,7 @@ func (a *App) ListCost(args []string) error {
 	// Display cost summary
 	a.displayCostSummary(summary, hasDiscounts, pricingConfig)
 
-	fmt.Printf("\n💡 Tip: Use 'prism list' for a clean workspace overview without cost data\n")
+	fmt.Printf("\n💡 Tip: Use 'prism workspace list' for a clean workspace overview without cost data\n")
 
 	return nil
 }
@@ -1829,7 +1829,7 @@ func (a *App) projectInstances(args []string) error {
 
 	if len(projectInstances) == 0 {
 		fmt.Printf("No instances found in project '%s'\n", projectName)
-		fmt.Printf("Launch one with: prism launch <template> <workspace-name> --project %s\n", projectName)
+		fmt.Printf("Launch one with: prism workspace launch <template> <workspace-name> --project %s\n", projectName)
 		return nil
 	}
 
@@ -2139,7 +2139,7 @@ func (a *App) monitorSetupProgress(instance *types.Instance, wait bool) error {
 			if !wait && elapsed > 30*time.Minute {
 				fmt.Printf("\n⚠️  Setup taking longer than expected\n")
 				fmt.Printf("💡 Progress: %.1f%% - Workspace may still be configuring\n", progress.OverallProgress)
-				fmt.Printf("💡 Check status with: prism list\n")
+				fmt.Printf("💡 Check status with: prism workspace list\n")
 				fmt.Printf("💡 To verify setup progress after connecting:\n")
 				fmt.Printf("   prism workspace connect %s  # then run: cloud-init status\n", instance.Name)
 				return nil

--- a/internal/cli/budget_commands.go
+++ b/internal/cli/budget_commands.go
@@ -756,7 +756,7 @@ func (bc *BudgetCommands) displayCreateBudgetSuccess(projectName string, amount 
 
 	fmt.Printf("\n💡 Next Steps:\n")
 	fmt.Printf("   prism budget status %s     # Check budget status\n", projectName)
-	fmt.Printf("   prism launch <template> <instance> --project %s  # Launch with budget tracking\n", projectName)
+	fmt.Printf("   prism workspace launch <template> <instance> --project %s  # Launch with budget tracking\n", projectName)
 }
 
 // updateBudget updates an existing budget
@@ -1268,8 +1268,8 @@ func (bc *BudgetCommands) displayStatusQuickActions(budgetID string, usagePercen
 	fmt.Printf("   prism budget breakdown %s    # See where money is spent\n", budgetID)
 	fmt.Printf("   prism budget savings %s      # Find cost optimization opportunities\n", budgetID)
 	if usagePercent >= 80 {
-		fmt.Printf("   prism list --project %s      # Review running instances\n", budgetID)
-		fmt.Printf("   prism hibernate <instance>   # Hibernate idle instances\n")
+		fmt.Printf("   prism workspace list --project %s      # Review running instances\n", budgetID)
+		fmt.Printf("   prism workspace hibernate <instance>   # Hibernate idle instances\n")
 	}
 }
 
@@ -1666,7 +1666,7 @@ func (bc *BudgetCommands) displaySavingsRecommendations(totalPotentialSavings fl
 
 	fmt.Printf("\n💡 Quick Actions:\n")
 	fmt.Printf("   prism idle profile create aggressive --idle-minutes 15\n")
-	fmt.Printf("   prism list | grep STOPPED  # Find stopped instances to terminate\n")
+	fmt.Printf("   prism workspace list | grep STOPPED  # Find stopped instances to terminate\n")
 	fmt.Printf("   prism rightsizing analyze  # Get right-sizing recommendations\n")
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1044,7 +1044,7 @@ func (s *TemplateSnapshotSaveService) saveTemplateAndDisplayResults(config *Temp
 	fmt.Printf("   Location: %s\n\n", templateFile)
 
 	fmt.Printf("🚀 **Usage**:\n")
-	fmt.Printf("   Launch new instance: prism launch \"%s\" new-instance\n", config.TemplateName)
+	fmt.Printf("   Launch new instance: prism workspace launch \"%s\" new-instance\n", config.TemplateName)
 	fmt.Printf("   View template info: prism templates info \"%s\"\n", config.TemplateName)
 	fmt.Printf("   Validate template: prism templates validate \"%s\"\n", config.TemplateName)
 

--- a/internal/cli/constants.go
+++ b/internal/cli/constants.go
@@ -100,10 +100,10 @@ const (
 	DaemonAutoStartFailedMessage = "❌ Failed to auto-start daemon. Please start manually with: prism daemon start"
 
 	// NoInstancesFoundMessage is displayed when no instances are found
-	NoInstancesFoundMessage = "No workstations found. Launch one with: prism launch <template> <name>"
+	NoInstancesFoundMessage = "No workstations found. Launch one with: prism workspace launch <template> <name>"
 
 	// NoInstancesFoundProjectMessage is displayed when no instances are found in a project
-	NoInstancesFoundProjectMessage = "No workstations found in project '%s'. Launch one with: prism launch <template> <name> --project %s"
+	NoInstancesFoundProjectMessage = "No workstations found in project '%s'. Launch one with: prism workspace launch <template> <name> --project %s"
 
 	// NoEFSVolumesFoundMessage is displayed when no EFS volumes are found
 	NoEFSVolumesFoundMessage = "No EFS volumes found. Create one with: prism volume create <name>"
@@ -193,13 +193,13 @@ const (
 	SetupTimeoutMessage = "⚠️  Setup monitoring timeout (20 min). Instance may still be setting up."
 
 	// SetupTimeoutHelpMessage provides help when setup times out
-	SetupTimeoutHelpMessage = "💡 Check status with: prism list"
+	SetupTimeoutHelpMessage = "💡 Check status with: prism workspace list"
 
 	// SetupTimeoutConnectMessage suggests connecting when setup times out
-	SetupTimeoutConnectMessage = "💡 Try connecting: prism connect %s"
+	SetupTimeoutConnectMessage = "💡 Try connecting: prism workspace connect %s"
 
 	// AMITimeoutMessage is displayed when AMI launch monitoring times out
-	AMITimeoutMessage = "⚠️  Timeout waiting for instance to start (5 min). Check status with: prism list"
+	AMITimeoutMessage = "⚠️  Timeout waiting for instance to start (5 min). Check status with: prism workspace list"
 )
 
 // =============================================================================
@@ -217,7 +217,7 @@ const (
 	StateMessageRunningReady = "✅ Instance running! Ready to connect."
 
 	// StateMessageConnectCommand provides the connect command template
-	StateMessageConnectCommand = "🔗 Connect: prism connect %s"
+	StateMessageConnectCommand = "🔗 Connect: prism workspace connect %s"
 
 	// StateMessageDryRunSuccess is displayed for successful dry runs
 	StateMessageDryRunSuccess = "✅ Dry-run validation successful! No actual instance launched."

--- a/internal/cli/constants_test.go
+++ b/internal/cli/constants_test.go
@@ -66,7 +66,7 @@ func TestUsageMessages(t *testing.T) {
 
 	// Test no instances messages
 	assert.Contains(t, NoInstancesFoundMessage, "No workstations found")
-	assert.Contains(t, NoInstancesFoundMessage, "prism launch")
+	assert.Contains(t, NoInstancesFoundMessage, "prism workspace launch")
 
 	assert.Contains(t, NoInstancesFoundProjectMessage, "No workstations found in project")
 	assert.Contains(t, NoInstancesFoundProjectMessage, "%s")

--- a/internal/cli/init_cobra.go
+++ b/internal/cli/init_cobra.go
@@ -407,7 +407,7 @@ func (ic *InitCobraCommands) reviewAndConfirm(template *templateInfo, name, size
 	costPerMonth := costPerHour * 730 // Average hours per month
 	fmt.Printf("  Estimated cost: $%.2f/hour (~$%.2f/month if running 24/7)\n", costPerHour, costPerMonth)
 	fmt.Println()
-	fmt.Println("💡 Tip: Use 'prism stop' when not in use to save costs")
+	fmt.Println("💡 Tip: Use 'prism workspace stop' when not in use to save costs")
 	fmt.Println()
 
 	// Confirm
@@ -458,9 +458,9 @@ func (ic *InitCobraCommands) displaySuccess(name string) error {
 	if err != nil {
 		// Still show basic success even if we can't get details
 		fmt.Println("📚 Next Steps:")
-		fmt.Println("  • Connect:  prism connect", name)
-		fmt.Println("  • Monitor:  prism list")
-		fmt.Println("  • Stop:     prism stop", name)
+		fmt.Println("  • Connect:  prism workspace connect", name)
+		fmt.Println("  • Monitor:  prism workspace list")
+		fmt.Println("  • Stop:     prism workspace stop", name)
 		fmt.Println()
 		return nil
 	}
@@ -484,10 +484,10 @@ func (ic *InitCobraCommands) displaySuccess(name string) error {
 
 	// Next steps
 	fmt.Println("📚 Next Steps:")
-	fmt.Println("  • Connect:  prism connect", name)
-	fmt.Println("  • Monitor:  prism list")
-	fmt.Println("  • Stop:     prism stop", name)
-	fmt.Println("  • Delete:   prism delete", name)
+	fmt.Println("  • Connect:  prism workspace connect", name)
+	fmt.Println("  • Monitor:  prism workspace list")
+	fmt.Println("  • Stop:     prism workspace stop", name)
+	fmt.Println("  • Delete:   prism workspace delete", name)
 	fmt.Println()
 	fmt.Println("💡 Run 'prism --help' to see all available commands")
 	fmt.Println()

--- a/internal/cli/instance_impl.go
+++ b/internal/cli/instance_impl.go
@@ -40,7 +40,7 @@ func NewInstanceCommands(app *App) *InstanceCommands {
 func (ic *InstanceCommands) Connect(args []string) error {
 	// Validate arguments
 	if len(args) < 1 {
-		return NewUsageError("prism connect <workspace-name>", "prism connect my-workspace")
+		return NewUsageError("prism workspace connect <workspace-name>", "prism workspace connect my-workspace")
 	}
 
 	// Parse flags
@@ -195,7 +195,7 @@ func (ic *InstanceCommands) connectWebInstance(instance *types.Instance, name st
 		fmt.Printf("🌐 Web services available for %s\n", name)
 		if len(instance.Services) > 0 {
 			fmt.Printf("   Services will be tunneled automatically when accessed\n")
-			fmt.Printf("   Use: prism connect %s\n", name)
+			fmt.Printf("   Use: prism workspace connect %s\n", name)
 		}
 	}
 	return nil
@@ -325,7 +325,7 @@ func (ic *InstanceCommands) startSSMPortForwarding(instanceID string, remotePort
 // Stop handles the stop command
 func (ic *InstanceCommands) Stop(args []string) error {
 	if len(args) < 1 {
-		return NewUsageError("prism stop <name>", "prism stop my-workspace")
+		return NewUsageError("prism workspace stop <name>", "prism workspace stop my-workspace")
 	}
 
 	name := args[0]
@@ -347,7 +347,7 @@ func (ic *InstanceCommands) Stop(args []string) error {
 // Start handles the start command with intelligent state management
 func (ic *InstanceCommands) Start(args []string) error {
 	if len(args) < 1 {
-		return NewUsageError("prism start <name>", "prism start my-workspace")
+		return NewUsageError("prism workspace start <name>", "prism workspace start my-workspace")
 	}
 
 	name := args[0]
@@ -372,7 +372,7 @@ func (ic *InstanceCommands) Start(args []string) error {
 	}
 
 	if targetInstance == nil {
-		return NewNotFoundError("workspace", name, "Use 'prism list' to see available instances")
+		return NewNotFoundError("workspace", name, "Use 'prism workspace list' to see available instances")
 	}
 
 	// Check current state and handle appropriately
@@ -381,8 +381,8 @@ func (ic *InstanceCommands) Start(args []string) error {
 		fmt.Printf("✅ Workspace %s is already running\n", name)
 		return nil
 	case "hibernated":
-		fmt.Printf("🛌 Workspace %s is hibernated - use 'prism resume %s' for instant startup\n", name, name)
-		fmt.Printf("   Or use 'prism start %s' for regular boot (slower)\n", name)
+		fmt.Printf("🛌 Workspace %s is hibernated - use 'prism workspace resume %s' for instant startup\n", name, name)
+		fmt.Printf("   Or use 'prism workspace start %s' for regular boot (slower)\n", name)
 		fmt.Printf("   Proceeding with regular start...\n")
 	case "stopped", "stopping":
 		// Normal case - proceed with start
@@ -402,7 +402,7 @@ func (ic *InstanceCommands) Start(args []string) error {
 // Delete handles the delete command
 func (ic *InstanceCommands) Delete(args []string) error {
 	if len(args) < 1 {
-		return NewUsageError("prism delete <name>", "prism delete my-workspace")
+		return NewUsageError("prism workspace delete <name>", "prism workspace delete my-workspace")
 	}
 
 	name := args[0]
@@ -424,7 +424,7 @@ func (ic *InstanceCommands) Delete(args []string) error {
 // Hibernate handles the hibernate command
 func (ic *InstanceCommands) Hibernate(args []string) error {
 	if len(args) < 1 {
-		return NewUsageError("prism hibernate <name>", "prism hibernate my-workspace")
+		return NewUsageError("prism workspace hibernate <name>", "prism workspace hibernate my-workspace")
 	}
 
 	name := args[0]
@@ -465,7 +465,7 @@ func (ic *InstanceCommands) Hibernate(args []string) error {
 // Resume handles the resume command
 func (ic *InstanceCommands) Resume(args []string) error {
 	if len(args) < 1 {
-		return NewUsageError("prism resume <name>", "prism resume my-workspace")
+		return NewUsageError("prism workspace resume <name>", "prism workspace resume my-workspace")
 	}
 
 	name := args[0]
@@ -507,7 +507,7 @@ func (ic *InstanceCommands) Resume(args []string) error {
 func (ic *InstanceCommands) Exec(args []string) error {
 	// Validate arguments
 	if len(args) < 2 {
-		return NewUsageError("prism exec <workspace-name> <command>", "prism exec my-workspace \"ls -la\"")
+		return NewUsageError("prism workspace exec <workspace-name> <command>", "prism workspace exec my-workspace \"ls -la\"")
 	}
 
 	// Parse command arguments and flags
@@ -752,7 +752,7 @@ func (ic *InstanceCommands) getInstanceForResize(instanceName string) (*types.In
 		}
 	}
 
-	return nil, NewNotFoundError("workspace", instanceName, "Use 'prism list' to see available instances")
+	return nil, NewNotFoundError("workspace", instanceName, "Use 'prism workspace list' to see available instances")
 }
 
 // resolveTargetInstanceType determines the target workspace type from options
@@ -903,8 +903,8 @@ func (ic *InstanceCommands) executeResize(instanceName, targetType string, opts 
 		return ic.monitorResizeProgress(instanceName)
 	}
 
-	fmt.Printf("💡 Monitor progress with: prism list\n")
-	fmt.Printf("💡 Check when ready: prism connect %s\n", instanceName)
+	fmt.Printf("💡 Monitor progress with: prism workspace list\n")
+	fmt.Printf("💡 Check when ready: prism workspace connect %s\n", instanceName)
 	return nil
 }
 
@@ -956,7 +956,7 @@ func (ic *InstanceCommands) monitorResizeProgress(instanceName string) error {
 		switch instance.State {
 		case "running":
 			fmt.Printf("✅ Resize complete! Instance is running with new configuration.\n")
-			fmt.Printf("🔗 Connect: prism connect %s\n", instanceName)
+			fmt.Printf("🔗 Connect: prism workspace connect %s\n", instanceName)
 			return nil
 		case "stopped", "stopping":
 			fmt.Printf("⏳ Instance stopping for resize... (%ds)\n", i*5)
@@ -972,6 +972,6 @@ func (ic *InstanceCommands) monitorResizeProgress(instanceName string) error {
 	}
 
 	fmt.Printf("⚠️  Resize monitoring timeout. Instance may still be resizing.\n")
-	fmt.Printf("💡 Check status with: prism list\n")
+	fmt.Printf("💡 Check status with: prism workspace list\n")
 	return nil
 }

--- a/internal/cli/keys_cobra.go
+++ b/internal/cli/keys_cobra.go
@@ -320,7 +320,7 @@ func (k *KeysCobraCommands) handleImportKey(profileName, region, keyFilePath str
 	fmt.Printf("   Source File: %s\n", keyFilePath)
 	fmt.Printf("\n💡 The key is now ready to use with Prism\n")
 	fmt.Printf("💡 View details: prism keys show %s\n", profileName)
-	fmt.Printf("💡 Launch an instance: prism launch <template> <name>\n")
+	fmt.Printf("💡 Launch an instance: prism workspace launch <template> <name>\n")
 
 	return nil
 }
@@ -368,7 +368,7 @@ func (k *KeysCobraCommands) handleDeleteKey(profileName string, force bool) erro
 		}
 		fmt.Printf("\n❌ Cannot delete key while instances are using it\n")
 		fmt.Printf("💡 Options:\n")
-		fmt.Printf("   1. Delete the instances first: prism delete <workspace-name>\n")
+		fmt.Printf("   1. Delete the instances first: prism workspace delete <workspace-name>\n")
 		fmt.Printf("   2. Force deletion (DANGEROUS): prism keys delete %s --force\n", profileName)
 		return fmt.Errorf("key is in use")
 	}

--- a/internal/cli/marketplace.go
+++ b/internal/cli/marketplace.go
@@ -255,7 +255,7 @@ func (a *App) handleMarketplaceInstall(args []string) error {
 
 	// Show usage examples
 	fmt.Printf("\n💻 Usage:\n")
-	fmt.Printf("   Launch: prism launch %s my-project\n", localName)
+	fmt.Printf("   Launch: prism workspace launch %s my-project\n", localName)
 	fmt.Printf("   Info: prism templates info %s\n", localName)
 	fmt.Printf("   List: prism templates list\n")
 
@@ -350,7 +350,7 @@ func (a *App) handleMarketplacePublish(args []string) error {
 	}
 
 	fmt.Printf("\n💡 View your template: prism marketplace info %s\n", getString(response, "template_id"))
-	fmt.Printf("💡 Launch your template: prism launch marketplace:%s my-project\n", getString(response, "template_id"))
+	fmt.Printf("💡 Launch your template: prism workspace launch marketplace:%s my-project\n", getString(response, "template_id"))
 
 	return nil
 }
@@ -456,7 +456,7 @@ func (a *App) handleMarketplaceFork(args []string) error {
 	fmt.Printf("🆔 Forked: %s\n", getString(response, "forked_template_id"))
 	fmt.Printf("📝 Name: %s\n", getString(response, "forked_template_name"))
 
-	fmt.Printf("\n💡 Launch your fork: prism launch marketplace:%s my-project\n",
+	fmt.Printf("\n💡 Launch your fork: prism workspace launch marketplace:%s my-project\n",
 		getString(response, "forked_template_id"))
 
 	return nil
@@ -611,7 +611,7 @@ func (a *App) displayTemplateList(templates []interface{}) error {
 			fmt.Printf("   %s\n", strings.Join(badges, " "))
 		}
 
-		fmt.Printf("   💻 Launch: prism launch marketplace:%s my-project\n",
+		fmt.Printf("   💻 Launch: prism workspace launch marketplace:%s my-project\n",
 			getString(template, "template_id"))
 		fmt.Printf("\n")
 	}
@@ -693,7 +693,7 @@ func (a *App) displayTemplateInfo(template map[string]interface{}) {
 
 	// Usage examples
 	fmt.Printf("\n💻 Usage:\n")
-	fmt.Printf("   Launch: prism launch marketplace:%s my-project\n", getString(template, "template_id"))
+	fmt.Printf("   Launch: prism workspace launch marketplace:%s my-project\n", getString(template, "template_id"))
 	fmt.Printf("   Info: prism marketplace info %s\n", getString(template, "template_id"))
 	fmt.Printf("   Review: prism marketplace review %s --rating 5 --title \"Great!\" --comment \"Works perfectly\"\n",
 		getString(template, "template_id"))

--- a/internal/cli/mock_api_client.go
+++ b/internal/cli/mock_api_client.go
@@ -224,7 +224,7 @@ func (m *MockAPIClient) LaunchInstance(ctx context.Context, req types.LaunchRequ
 		Instance:       instance,
 		Message:        fmt.Sprintf("Instance %s launched successfully", req.Name),
 		EstimatedCost:  "$2.40/day",
-		ConnectionInfo: fmt.Sprintf("prism connect %s", req.Name),
+		ConnectionInfo: fmt.Sprintf("prism workspace connect %s", req.Name),
 	}, nil
 }
 

--- a/internal/cli/profile_wizard.go
+++ b/internal/cli/profile_wizard.go
@@ -397,7 +397,7 @@ func (pw *ProfileWizard) showProfileCreated(newProfile profile.Profile) {
 	fmt.Println("💡 What's next?")
 	fmt.Println("   • List all profiles: prism profiles list")
 	fmt.Println("   • Switch profiles: prism profiles switch <profile-id>")
-	fmt.Println("   • Launch an instance: prism launch python-ml my-project")
+	fmt.Println("   • Launch an instance: prism workspace launch python-ml my-project")
 	fmt.Println()
 }
 

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -666,7 +666,7 @@ func runProfilesMainCommand(config *Config) {
 		fmt.Println()
 		fmt.Println()
 		fmt.Println("💡 Your Prism is ready to use! Try:")
-		fmt.Println("   prism launch python-ml my-project")
+		fmt.Println("   prism workspace launch python-ml my-project")
 		fmt.Println()
 
 		reader := bufio.NewReader(os.Stdin)

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -244,7 +244,7 @@ func (pr *ProgressReporter) ShowCompletion(instance *types.Instance) {
 		fmt.Printf("🌐 Public IP: %s\n", instance.PublicIP)
 	}
 
-	fmt.Printf("🔗 Connect: prism connect %s\n", pr.instanceName)
+	fmt.Printf("🔗 Connect: prism workspace connect %s\n", pr.instanceName)
 
 	// Show setup summary
 	if pr.templateType == "package" {
@@ -270,7 +270,7 @@ func (pr *ProgressReporter) ShowError(err error, instance *types.Instance) {
 
 	fmt.Printf("💡 Troubleshooting:\n")
 	fmt.Printf("   • Check logs: prism daemon logs\n")
-	fmt.Printf("   • Retry with: prism launch %s %s\n", pr.templateName, pr.instanceName)
+	fmt.Printf("   • Retry with: prism workspace launch %s %s\n", pr.templateName, pr.instanceName)
 	fmt.Printf("   • Try different region: --region us-west-2\n")
 	fmt.Printf("   • Try smaller size: --size S\n")
 }

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -461,7 +461,7 @@ func (a *App) repoPull(args []string) error {
 
 	fmt.Printf("\n✅ Template downloaded successfully\n")
 	fmt.Printf("   File: %s\n", destFile)
-	fmt.Printf("   Use: prism launch %s <workspace-name>\n", ref.Template)
+	fmt.Printf("   Use: prism workspace launch %s <workspace-name>\n", ref.Template)
 
 	return nil
 }

--- a/internal/cli/scaling_impl.go
+++ b/internal/cli/scaling_impl.go
@@ -449,7 +449,7 @@ func (s *ScalingCommands) rightsizingExport(args []string) error {
 		}
 	}
 	if instance == nil {
-		return NewNotFoundError("workspace", instanceName, "Use 'prism list' to see available instances")
+		return NewNotFoundError("workspace", instanceName, "Use 'prism workspace list' to see available instances")
 	}
 
 	fmt.Printf("📊 **Usage Analytics Export**\n")
@@ -469,7 +469,7 @@ func (s *ScalingCommands) rightsizingExport(args []string) error {
 
 	fmt.Printf("💻 **Command to Access Data**:\n")
 	fmt.Printf("   # Connect to workspace and view analytics\n")
-	fmt.Printf("   prism connect %s\n", instanceName)
+	fmt.Printf("   prism workspace connect %s\n", instanceName)
 	fmt.Printf("   \n")
 	fmt.Printf("   # Then on the instance:\n")
 	fmt.Printf("   sudo cat %s | jq .\n", AnalyticsLogFile)
@@ -650,7 +650,7 @@ func (s *ScalingCommands) scalingAnalyze(args []string) error {
 		}
 	}
 	if instance == nil {
-		return NewNotFoundError("workspace", instanceName, "Use 'prism list' to see available instances")
+		return NewNotFoundError("workspace", instanceName, "Use 'prism workspace list' to see available instances")
 	}
 
 	fmt.Printf("📊 **Current Instance Configuration**:\n")
@@ -666,7 +666,7 @@ func (s *ScalingCommands) scalingAnalyze(args []string) error {
 	if instance.State != "running" {
 		fmt.Printf("\n⚠️  **Instance Not Running**\n")
 		fmt.Printf("   Instance must be running to collect usage analytics.\n")
-		fmt.Printf("   Start instance: prism start %s\n", instanceName)
+		fmt.Printf("   Start instance: prism workspace start %s\n", instanceName)
 		return nil
 	}
 
@@ -725,7 +725,7 @@ func (s *ScalingCommands) scalingPredict(args []string) error {
 		}
 	}
 	if instance == nil {
-		return NewNotFoundError("workspace", instanceName, "Use 'prism list' to see available instances")
+		return NewNotFoundError("workspace", instanceName, "Use 'prism workspace list' to see available instances")
 	}
 
 	fmt.Printf("📊 **Instance Analysis**:\n")
@@ -739,7 +739,7 @@ func (s *ScalingCommands) scalingPredict(args []string) error {
 	if instance.State != "running" {
 		fmt.Printf("⚠️  **Instance Not Running**\n")
 		fmt.Printf("   Predictive analysis requires running instance with usage data.\n")
-		fmt.Printf("   Start instance: prism start %s\n", instanceName)
+		fmt.Printf("   Start instance: prism workspace start %s\n", instanceName)
 		fmt.Printf("   Allow 1+ hours of runtime for meaningful predictions.\n")
 		return nil
 	}
@@ -915,7 +915,7 @@ func (s *ScalingCommands) scalingScale(args []string) error {
 		}
 	}
 	if instance == nil {
-		return NewNotFoundError("workspace", instanceName, "Use 'prism list' to see available instances")
+		return NewNotFoundError("workspace", instanceName, "Use 'prism workspace list' to see available instances")
 	}
 
 	currentSize := s.parseInstanceSize(instance.InstanceType)
@@ -956,9 +956,9 @@ func (s *ScalingCommands) scalingScale(args []string) error {
 	fmt.Printf("   Currently showing preview mode - full implementation pending.\n\n")
 
 	fmt.Printf("🛠️  **Manual Scaling Process**:\n")
-	fmt.Printf("   1. Stop instance: prism stop %s\n", instanceName)
+	fmt.Printf("   1. Stop instance: prism workspace stop %s\n", instanceName)
 	fmt.Printf("   2. Modify via AWS Console or CLI\n")
-	fmt.Printf("   3. Start instance: prism start %s\n\n", instanceName)
+	fmt.Printf("   3. Start instance: prism workspace start %s\n\n", instanceName)
 
 	fmt.Printf("🚧 **Implementation Status**: Preview Mode\n")
 	fmt.Printf("   Full dynamic scaling will be implemented in future release.\n")
@@ -1003,7 +1003,7 @@ func (s *ScalingCommands) scalingPreview(args []string) error {
 		}
 	}
 	if instance == nil {
-		return NewNotFoundError("workspace", instanceName, "Use 'prism list' to see available instances")
+		return NewNotFoundError("workspace", instanceName, "Use 'prism workspace list' to see available instances")
 	}
 
 	currentSize := s.parseInstanceSize(instance.InstanceType)
@@ -1090,7 +1090,7 @@ func (s *ScalingCommands) scalingHistory(args []string) error {
 		}
 	}
 	if instance == nil {
-		return NewNotFoundError("workspace", instanceName, "Use 'prism list' to see available instances")
+		return NewNotFoundError("workspace", instanceName, "Use 'prism workspace list' to see available instances")
 	}
 
 	fmt.Printf("🏷️  **Instance**: %s\n", instance.Name)

--- a/internal/cli/snapshot_impl.go
+++ b/internal/cli/snapshot_impl.go
@@ -310,8 +310,8 @@ func (s *SnapshotCommands) restoreSnapshot(args []string) error {
 		return s.app.monitorLaunchProgress(result.NewInstanceName, result.SourceTemplate, req.Wait)
 	}
 
-	fmt.Printf("\n💡 Check progress with: prism list\n")
-	fmt.Printf("💡 Connect when ready: prism connect %s\n", result.NewInstanceName)
+	fmt.Printf("\n💡 Check progress with: prism workspace list\n")
+	fmt.Printf("💡 Connect when ready: prism workspace connect %s\n", result.NewInstanceName)
 
 	return nil
 }

--- a/internal/cli/template_apply.go
+++ b/internal/cli/template_apply.go
@@ -133,7 +133,7 @@ func (a *App) Rollback(args []string) error {
 
 	fmt.Printf("✅ Successfully rolled back instance '%s' to checkpoint '%s'\n", instanceName, checkpointID)
 	fmt.Printf("💡 Use 'prism layers %s' to see the current state\n", instanceName)
-	fmt.Printf("💡 Use 'prism list' to verify the instance is healthy\n")
+	fmt.Printf("💡 Use 'prism workspace list' to verify the instance is healthy\n")
 
 	return nil
 }

--- a/internal/cli/template_impl.go
+++ b/internal/cli/template_impl.go
@@ -97,8 +97,8 @@ func (tc *TemplateCommands) templatesList(args []string) error {
 	}
 
 	fmt.Println("🚀 How to Launch:")
-	fmt.Println("   Using slug:        prism launch python-ml my-project")
-	fmt.Println("   Using full name:   prism launch \"Python Machine Learning (Simplified)\" my-project")
+	fmt.Println("   Using slug:        prism workspace launch python-ml my-project")
+	fmt.Println("   Using full name:   prism workspace launch \"Python Machine Learning (Simplified)\" my-project")
 	fmt.Println()
 
 	fmt.Println("📦 Package Manager Types:")
@@ -268,7 +268,7 @@ func (tc *TemplateCommands) displaySingleResult(result templates.SearchResult, q
 
 	// Display metadata
 	if tmpl.Slug != "" {
-		fmt.Printf("   Quick launch: prism launch %s <name>\n", tmpl.Slug)
+		fmt.Printf("   Quick launch: prism workspace launch %s <name>\n", tmpl.Slug)
 	}
 	fmt.Printf("   %s\n", tmpl.Description)
 
@@ -364,7 +364,7 @@ func (tc *TemplateCommands) displayTemplateHeader() {
 func (tc *TemplateCommands) displayBasicInfo(template *templates.Template) {
 	fmt.Printf("🏗️  **Name**: %s\n", template.Name)
 	if template.Slug != "" {
-		fmt.Printf("🔗 **Slug**: %s (for CLI: `prism launch %s <name>`)\n", template.Slug, template.Slug)
+		fmt.Printf("🔗 **Slug**: %s (for CLI: `prism workspace launch %s <name>`)\n", template.Slug, template.Slug)
 	}
 	fmt.Printf("📝 **Description**: %s\n", template.Description)
 	fmt.Printf("🖥️  **Base OS**: %s\n", template.Base)
@@ -533,7 +533,7 @@ func (tc *TemplateCommands) displayResearchUserInfo(template *templates.Template
 	if launchName == "" {
 		launchName = fmt.Sprintf("\"%s\"", template.Name)
 	}
-	fmt.Printf("   • 🚀 **Usage**: `prism launch %s my-project --research-user alice`\n", launchName)
+	fmt.Printf("   • 🚀 **Usage**: `prism workspace launch %s my-project --research-user alice`\n", launchName)
 
 	fmt.Println()
 }
@@ -592,10 +592,10 @@ func (tc *TemplateCommands) displayUsageExamples(template *templates.Template) {
 	if launchName == "" {
 		launchName = fmt.Sprintf("\"%s\"", template.Name)
 	}
-	fmt.Printf("   • Basic launch:        `prism launch %s my-workspace`\n", launchName)
-	fmt.Printf("   • Large instance:      `prism launch %s my-workspace --size L`\n", launchName)
-	fmt.Printf("   • With project:        `prism launch %s my-workspace --project my-research`\n", launchName)
-	fmt.Printf("   • Spot instance:       `prism launch %s my-workspace --spot`\n", launchName)
+	fmt.Printf("   • Basic launch:        `prism workspace launch %s my-workspace`\n", launchName)
+	fmt.Printf("   • Large instance:      `prism workspace launch %s my-workspace --size L`\n", launchName)
+	fmt.Printf("   • With project:        `prism workspace launch %s my-workspace --project my-research`\n", launchName)
+	fmt.Printf("   • Spot instance:       `prism workspace launch %s my-workspace --spot`\n", launchName)
 }
 
 // templatesFeatured shows featured templates from repositories
@@ -621,7 +621,7 @@ func (tc *TemplateCommands) templatesFeatured(args []string) error {
 		fmt.Printf("🏆 %s:%s (%s)\n", tmpl.repo, tmpl.name, tmpl.featured)
 		fmt.Printf("   %s\n", tmpl.description)
 		fmt.Printf("   Category: %s\n", tmpl.category)
-		fmt.Printf("   Launch: prism launch %s:%s <workspace-name>\n", tmpl.repo, tmpl.name)
+		fmt.Printf("   Launch: prism workspace launch %s:%s <workspace-name>\n", tmpl.repo, tmpl.name)
 		fmt.Println()
 	}
 
@@ -826,7 +826,7 @@ func (tc *TemplateCommands) templatesInstall(args []string) error {
 	fmt.Printf("📥 Installing template dependencies...\n")
 	fmt.Printf("✅ Template '%s' installed successfully\n", templateName)
 
-	fmt.Printf("\n🚀 Launch with: prism launch %s <workspace-name>\n", templateName)
+	fmt.Printf("\n🚀 Launch with: prism workspace launch %s <workspace-name>\n", templateName)
 	fmt.Printf("📋 Get details: prism templates info %s\n", templateName)
 
 	return nil

--- a/internal/tui/models/dashboard.go
+++ b/internal/tui/models/dashboard.go
@@ -273,7 +273,7 @@ func (m DashboardModel) View() string {
 		// Build instances panel
 		var instancesContent string
 		if len(m.instances) == 0 {
-			instancesContent = theme.Help.Render("No workspaces running.\nprism launch <template> <name>")
+			instancesContent = theme.Help.Render("No workspaces running.\nprism workspace launch <template> <name>")
 		} else {
 			instancesContent = m.instancesTable.View()
 		}

--- a/internal/tui/models/instances.go
+++ b/internal/tui/models/instances.go
@@ -317,7 +317,7 @@ func (m InstancesModel) View() string {
 			Width(m.width).
 			Height(m.height-4).
 			Align(lipgloss.Center, lipgloss.Center).
-			Render("No workspaces found. Use 'prism launch' to create one.")
+			Render("No workspaces found. Use 'prism workspace launch' to create one.")
 	} else {
 		// Main instances table
 		content = m.instancesTable.View()

--- a/internal/tui/models/templates.go
+++ b/internal/tui/models/templates.go
@@ -249,13 +249,13 @@ func (m *TemplatesModel) updateDetailView() {
 		}
 
 		content.WriteString(theme.SubTitle.Render("Launch Command:") + "\n")
-		content.WriteString(fmt.Sprintf("prism launch %s instance-name\n", m.selected))
-		content.WriteString("prism launch " + m.selected + " instance-name --size L\n")
-		content.WriteString("prism launch " + m.selected + " instance-name --volume data-volume\n")
+		content.WriteString(fmt.Sprintf("prism workspace launch %s instance-name\n", m.selected))
+		content.WriteString("prism workspace launch " + m.selected + " instance-name --size L\n")
+		content.WriteString("prism workspace launch " + m.selected + " instance-name --volume data-volume\n")
 
 		// Add research user launch example if supported
 		if template.ResearchUser != nil && template.ResearchUser.AutoCreate {
-			content.WriteString("prism launch " + m.selected + " instance-name --research-user alice\n")
+			content.WriteString("prism workspace launch " + m.selected + " instance-name --research-user alice\n")
 		}
 
 		m.detailView.SetContent(content.String())

--- a/pkg/aws/manager_operations_unit_test.go
+++ b/pkg/aws/manager_operations_unit_test.go
@@ -187,17 +187,17 @@ func TestManagerIntegrationPoints(t *testing.T) {
 			description string
 		}{
 			{
-				workflow:    "prism launch python-ml my-project",
+				workflow:    "prism workspace launch python-ml my-project",
 				testFocus:   "Template resolution + EC2 RunInstances + State update",
 				description: "Users launch instances from templates",
 			},
 			{
-				workflow:    "prism stop my-project",
+				workflow:    "prism workspace stop my-project",
 				testFocus:   "Instance lookup by name + EC2 StopInstances",
 				description: "Users stop running instances",
 			},
 			{
-				workflow:    "prism hibernate my-project",
+				workflow:    "prism workspace hibernate my-project",
 				testFocus:   "Hibernation capability check + fallback to stop",
 				description: "Users hibernate instances for cost savings",
 			},
@@ -207,7 +207,7 @@ func TestManagerIntegrationPoints(t *testing.T) {
 				description: "Users create shared storage volumes",
 			},
 			{
-				workflow:    "prism delete my-project",
+				workflow:    "prism workspace delete my-project",
 				testFocus:   "Instance termination + State cleanup",
 				description: "Users clean up instances",
 			},

--- a/pkg/sleepwake/monitor.go
+++ b/pkg/sleepwake/monitor.go
@@ -261,7 +261,7 @@ func (m *Monitor) handleWake(event Event) {
 
 	if !m.config.ResumeOnWake {
 		log.Println("Resume on wake is disabled, instances remain hibernated")
-		log.Println("Use 'prism start <instance>' to manually resume instances")
+		log.Println("Use 'prism workspace start <instance>' to manually resume instances")
 		return
 	}
 

--- a/pkg/web/dashboard.go
+++ b/pkg/web/dashboard.go
@@ -596,17 +596,17 @@ async function loadCostAnalysis() {
 
 // Instance actions
 function connectSSH(instanceName) {
-    alert('SSH connection command:\\n\\nprism connect ' + instanceName);
+    alert('SSH connection command:\\n\\nprism workspace connect ' + instanceName);
 }
 
 async function stopInstance(instanceId) {
     if (confirm('Are you sure you want to stop this instance?')) {
-        alert('Stop command:\\n\\nprism stop ' + instanceId);
+        alert('Stop command:\\n\\nprism workspace stop ' + instanceId);
     }
 }
 
 async function startInstance(instanceId) {
-    alert('Start command:\\n\\nprism start ' + instanceId);
+    alert('Start command:\\n\\nprism workspace start ' + instanceId);
 }
 
 // Add additional styles for new elements

--- a/test/integration/personas_test.go
+++ b/test/integration/personas_test.go
@@ -39,7 +39,7 @@ func TestSoloResearcherPersona(t *testing.T) {
 
 	t.Run("Phase1_LaunchBioinformaticsWorkspace", func(t *testing.T) {
 		// Launch instance with bioinformatics template
-		// Per walkthrough: "prism launch bioinformatics-suite rnaseq-analysis --size M"
+		// Per walkthrough: "prism workspace launch bioinformatics-suite rnaseq-analysis --size M"
 		// Using Python ML Workstation template (slug: python-ml-workstation)
 		instance, err := ctx.LaunchInstance("python-ml-workstation", instanceName, "M")
 		AssertNoError(t, err, "Launch bioinformatics workspace")
@@ -128,7 +128,7 @@ func TestSoloResearcherPersona(t *testing.T) {
 		t.Logf("✅ Instance hibernated successfully")
 
 		// Resume from hibernation
-		// Per walkthrough: "prism start rnaseq-analysis" (resumes in 30 seconds)
+		// Per walkthrough: "prism workspace start rnaseq-analysis" (resumes in 30 seconds)
 		err = ctx.StartInstance(instanceName)
 		AssertNoError(t, err, "Resume from hibernation")
 
@@ -178,7 +178,7 @@ func TestSoloResearcherPersona(t *testing.T) {
 
 	t.Run("Phase6_Cleanup", func(t *testing.T) {
 		// Delete instance
-		// Per walkthrough: "prism delete rnaseq-analysis"
+		// Per walkthrough: "prism workspace delete rnaseq-analysis"
 		err := ctx.DeleteInstance(instanceName)
 		AssertNoError(t, err, "Delete instance")
 
@@ -274,7 +274,7 @@ func TestSoloResearcherPersona_Complete(t *testing.T) {
 
 	t.Run("Week1_LaunchBioinformaticsWorkspace", func(t *testing.T) {
 		// Launch bioinformatics workspace (size M, ~$0.16/hour)
-		// Per walkthrough: "prism launch bioinformatics-suite rnaseq-analysis --size M"
+		// Per walkthrough: "prism workspace launch bioinformatics-suite rnaseq-analysis --size M"
 		t.Log("Launching bioinformatics workspace...")
 
 		instance, err := ctx.LaunchInstance("python-ml-workstation", instanceName, "M")


### PR DESCRIPTION
## Summary

- Error messages, help text, usage hints, and test descriptions throughout
  the codebase referenced legacy command paths like `prism launch`,
  `prism connect`, `prism list`, `prism stop`, `prism start`, `prism delete`,
  `prism hibernate`, `prism resume`, and `prism exec`. The actual CLI structure
  requires the `workspace` prefix (e.g., `prism workspace launch`). Users
  following the old instructions got "unknown command" errors.
- Fixed 111 occurrences across 28 files (CLI, TUI, GUI, web dashboard,
  sleep/wake monitor, integration tests, unit tests).

## Test plan

- [x] `make build` passes
- [x] Relevant unit tests pass (constants, usage messages, TUI settings/dashboard)
- [x] Grep confirms zero remaining `"prism (launch|connect|list|stop|start|delete|hibernate|resume|exec) ` references without `workspace` prefix
- [ ] Manual: run `prism workspace launch nonexistent foo` and verify error message shows `prism workspace ...`

**Note**: `TestTemplateCommands_Templates/Validate_subcommand` fails pre-existing due to a broken local template inheritance chain, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)