### PR TITLE
fix: allow deleting dry-run instances without AWS call

### DIFF
--- a/pkg/daemon/handlers_test.go
+++ b/pkg/daemon/handlers_test.go
@@ -178,6 +178,52 @@ func TestHandleGetInstance(t *testing.T) {
 	}
 }
 
+// TestHandleDeleteDryRunInstance tests that dry-run instances can be deleted
+// without attempting AWS operations. Dry-run instances are created by
+// "prism workspace launch --dry-run" and never exist on AWS.
+func TestHandleDeleteDryRunInstance(t *testing.T) {
+	server := createTestServer(t)
+	handler := server.createHTTPHandler()
+
+	// Seed a dry-run instance in state
+	dryRunInstance := types.Instance{
+		Name:  "test-dry-run",
+		State: "dry-run",
+		ID:    "",
+	}
+	err := server.stateManager.SaveInstance(dryRunInstance)
+	require.NoError(t, err)
+
+	// Verify it exists
+	state, err := server.stateManager.LoadState()
+	require.NoError(t, err)
+	_, exists := state.Instances["test-dry-run"]
+	require.True(t, exists, "dry-run instance should exist in state before delete")
+
+	// Delete it
+	req := httptest.NewRequest("DELETE", "/api/v1/instances/test-dry-run", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	// Verify it was removed from state
+	state, err = server.stateManager.LoadState()
+	require.NoError(t, err)
+	_, exists = state.Instances["test-dry-run"]
+	assert.False(t, exists, "dry-run instance should be removed from state after delete")
+}
+
+// TestHandleDeleteNonExistentInstance tests that deleting a non-existent instance returns 404
+func TestHandleDeleteNonExistentInstance(t *testing.T) {
+	server := createTestServer(t)
+	handler := server.createHTTPHandler()
+
+	req := httptest.NewRequest("DELETE", "/api/v1/instances/does-not-exist", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 // TestHandleInstanceActions tests instance control actions (start, stop, terminate)
 func TestHandleInstanceActions(t *testing.T) {
 	server := createTestServer(t)

--- a/pkg/daemon/instance_handlers.go
+++ b/pkg/daemon/instance_handlers.go
@@ -866,6 +866,13 @@ func (s *Server) handleDeleteInstance(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 
+	// Dry-run instances were never launched on AWS, so just remove from local state
+	if instance, exists := state.Instances[instanceName]; exists && instance.State == "dry-run" {
+		_ = s.stateManager.RemoveInstance(instanceName)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	// Initiate AWS deletion and refresh state from AWS
 	var deleteErr error
 	var updatedInstance *types.Instance


### PR DESCRIPTION
## Summary

- Dry-run instances (created by `prism workspace launch --dry-run`) only exist in local state and were never launched on AWS. Deleting them previously failed with a 500 error because the daemon attempted to terminate them on AWS.
- Added a check in `handleDeleteInstance` that detects dry-run state and removes the instance from local state directly, skipping the AWS call.
- Added tests for deleting dry-run instances and deleting non-existent instances.

## Test plan

- [x] `TestHandleDeleteDryRunInstance` -- seeds a dry-run instance, deletes via API, verifies 204 response and removal from state
- [x] `TestHandleDeleteNonExistentInstance` -- verifies 404 for missing instances
- [x] Full `go test ./pkg/daemon/` passes
- [ ] Manual test: `prism workspace launch <template> <name> --dry-run` then `prism workspace delete <name>` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)