### PR TITLE
Fix: wire up orphaned ListCost as 'prism workspace cost'

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -897,7 +897,7 @@ func printRunningCostSummary(instances []types.Instance) {
 		fmt.Printf("   Total accumulated:  $%.4f (since launch)\n", totalCurrent)
 		fmt.Printf("   Effective rate:     $%.4f/hr (actual usage)\n", totalEffective)
 		fmt.Printf("   Estimated daily:    $%.2f (at current rate)\n", totalEffective*24)
-		fmt.Printf("\n💡 Tip: Use 'prism list cost' for detailed cost breakdown with savings analysis\n")
+		fmt.Printf("\n💡 Tip: Use 'prism workspace cost' for detailed cost breakdown with savings analysis\n")
 	}
 }
 
@@ -1020,7 +1020,7 @@ func (a *App) ListCost(args []string) error {
 	// Display cost summary
 	a.displayCostSummary(summary, hasDiscounts, pricingConfig)
 
-	fmt.Printf("\n💡 Tip: Use 'prism list' for a clean workspace overview without cost data\n")
+	fmt.Printf("\n💡 Tip: Use 'prism workspace list' for a clean workspace overview without cost data\n")
 
 	return nil
 }

--- a/internal/cli/workspace_commands.go
+++ b/internal/cli/workspace_commands.go
@@ -28,6 +28,7 @@ Examples:
 	// Add subcommands
 	cmd.AddCommand(f.createLaunchCommand())
 	cmd.AddCommand(f.createListCommand())
+	cmd.AddCommand(f.createCostCommand())
 	cmd.AddCommand(f.createStartCommand())
 	cmd.AddCommand(f.createStopCommand())
 	cmd.AddCommand(f.createDeleteCommand())
@@ -143,6 +144,24 @@ func (f *WorkspaceCommandFactory) createListCommand() *cobra.Command {
 	}
 	cmd.Flags().BoolP("refresh", "r", false, "Refresh instance data from AWS (slower but accurate)")
 	cmd.Flags().BoolP("detailed", "d", false, "Show detailed instance information")
+	cmd.Flags().String("project", "", "Filter by project ID")
+	return cmd
+}
+
+func (f *WorkspaceCommandFactory) createCostCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cost",
+		Short: "Detailed cost breakdown with savings analysis",
+		Long: `Show detailed cost analysis for all workspaces, including running time,
+per-minute costs, monthly estimates, and institutional discount savings.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flagArgs []string
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				flagArgs = append(flagArgs, "--project", project)
+			}
+			return f.app.ListCost(flagArgs)
+		},
+	}
 	cmd.Flags().String("project", "", "Filter by project ID")
 	return cmd
 }


### PR DESCRIPTION
## Summary
- `ListCost` method existed in `app.go` with passing tests but was never registered in the cobra command tree
- The tip shown after `prism workspace list` referenced `prism list cost`, which does not exist
- Adds `prism workspace cost` subcommand (with `--project` filter support)
- Fixes both tip messages to reference correct command paths (`prism workspace cost` and `prism workspace list`)

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `TestListCostCommand` passes (4 subtests)
- [x] `TestListCommand` passes with updated tip text
- [x] `prism workspace --help` shows `cost` subcommand
- [ ] Manual: `prism workspace cost` shows detailed cost breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)