### PR TITLE
Fix: skip broken template inheritance instead of aborting scan

### DIFF
--- a/pkg/templates/parser.go
+++ b/pkg/templates/parser.go
@@ -646,7 +646,15 @@ func (r *TemplateRegistry) ResolveInheritance() error {
 	for _, template := range templatesWithInheritance {
 		resolved, err := r.resolveTemplateInheritance(template)
 		if err != nil {
-			return fmt.Errorf("failed to resolve inheritance for template %s: %w", template.Name, err)
+			// Warn and remove the broken template instead of aborting the entire scan.
+			// A missing parent (e.g. user template referencing a base template that
+			// isn't in the scanned directories) should not block all template operations.
+			fmt.Fprintf(os.Stderr, "Warning: skipping template %s: %v\n", template.Name, err)
+			delete(r.Templates, template.Name)
+			if template.Slug != "" {
+				delete(r.SlugIndex, template.Slug)
+			}
+			continue
 		}
 
 		// Replace original template with resolved one

--- a/pkg/templates/parser_test.go
+++ b/pkg/templates/parser_test.go
@@ -758,16 +758,23 @@ func TestTemplateRegistry_ResolveInheritance(t *testing.T) {
 func TestTemplateRegistry_ResolveInheritance_Errors(t *testing.T) {
 	registry := NewTemplateRegistry([]string{})
 
-	// Test missing parent template
+	// Test missing parent template: should warn and remove the broken
+	// template rather than aborting the entire inheritance pass.
 	child := &Template{
 		Name:        "Child",
+		Slug:        "child",
 		Description: "Child template",
 		Base:        "ubuntu-22.04",
 		Inherits:    []string{"NonexistentParent"},
 	}
 	registry.Templates["Child"] = child
+	registry.SlugIndex["child"] = "Child"
 
 	err := registry.ResolveInheritance()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "parent template not found: NonexistentParent")
+	assert.NoError(t, err)
+	// The broken template should have been removed from the registry
+	_, exists := registry.Templates["Child"]
+	assert.False(t, exists, "broken template should be removed from registry")
+	_, slugExists := registry.SlugIndex["child"]
+	assert.False(t, slugExists, "broken template slug should be removed from index")
 }


### PR DESCRIPTION
## Summary
- `ResolveInheritance` previously returned a hard error when any template's parent was missing, which blocked all template operations (`validate`, `version list`, `discover`, etc.)
- This happens in practice when a user template in `~/.prism/templates/` references a parent that only exists in the repo's `templates/base/` directory, which isn't always in the scanned paths
- Now it warns on stderr and removes the broken template from the registry, matching how YAML parse errors are already handled in `ScanTemplates`
- Updated the existing `TestTemplateRegistry_ResolveInheritance_Errors` test to verify the new warn-and-remove behavior

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `TestTemplateRegistry_ResolveInheritance` passes (valid inheritance still works)
- [x] `TestTemplateRegistry_ResolveInheritance_Errors` passes (broken template removed, no error returned)
- [x] `TestTemplateCommands_Templates` passes all 11 subtests (previously `Validate_subcommand` and `Version_subcommand` failed)
- [x] `go test ./pkg/templates/` -- all tests pass
- [x] `go test ./internal/cli/` -- all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)