### PR TITLE
fix(daemon): optimistic state cache after lifecycle ops

### DIFF
--- a/pkg/daemon/handlers_test.go
+++ b/pkg/daemon/handlers_test.go
@@ -245,6 +245,36 @@ func TestHandleInstanceActions(t *testing.T) {
 	}
 }
 
+// TestApplyExpectedTransitionalState tests the optimistic state helper
+func TestApplyExpectedTransitionalState(t *testing.T) {
+	t.Run("applies transitional state when AWS has not caught up", func(t *testing.T) {
+		inst := &types.Instance{State: "running"}
+		applyExpectedTransitionalState(inst, "running", "stopping")
+		assert.Equal(t, "stopping", inst.State)
+		require.Len(t, inst.StateHistory, 1)
+		assert.Equal(t, "running", inst.StateHistory[0].FromState)
+		assert.Equal(t, "stopping", inst.StateHistory[0].ToState)
+	})
+
+	t.Run("no-op when AWS already reports expected state", func(t *testing.T) {
+		inst := &types.Instance{State: "stopping"}
+		applyExpectedTransitionalState(inst, "running", "stopping")
+		assert.Equal(t, "stopping", inst.State)
+		assert.Empty(t, inst.StateHistory)
+	})
+
+	t.Run("no-op for nil instance", func(t *testing.T) {
+		applyExpectedTransitionalState(nil, "running", "stopping")
+		// no panic is the assertion
+	})
+
+	t.Run("start: stopped to pending", func(t *testing.T) {
+		inst := &types.Instance{State: "stopped"}
+		applyExpectedTransitionalState(inst, "stopped", "pending")
+		assert.Equal(t, "pending", inst.State)
+	})
+}
+
 // TestHandleTemplates tests the template listing endpoint
 func TestHandleTemplates(t *testing.T) {
 	server := createTestServer(t)

--- a/pkg/daemon/instance_handlers.go
+++ b/pkg/daemon/instance_handlers.go
@@ -1003,6 +1003,26 @@ func (s *Server) refreshInstanceStateFromAWS(awsManager *aws.Manager, instanceNa
 	return liveInstance
 }
 
+// applyExpectedTransitionalState sets the instance to the expected transitional
+// state when AWS DescribeInstances has not caught up after a state-changing API
+// call. EC2 state changes are not instantaneous: StopInstances returns success
+// as soon as the request is accepted, but DescribeInstances may still report
+// the old state for several seconds. Without this, the cached state stays stale
+// until the next explicit --refresh, making "workspace list" show the old state.
+func applyExpectedTransitionalState(instance *types.Instance, fromState, toState string) {
+	if instance == nil || instance.State != fromState {
+		return
+	}
+	instance.State = toState
+	instance.StateHistory = append(instance.StateHistory, types.StateTransition{
+		FromState: fromState,
+		ToState:   toState,
+		Timestamp: time.Now(),
+		Reason:    "user_action",
+		Initiator: "user",
+	})
+}
+
 // handleStartInstance starts a stopped instance
 func (s *Server) handleStartInstance(w http.ResponseWriter, r *http.Request, identifier string) {
 	if r.Method != http.MethodPost {
@@ -1033,6 +1053,7 @@ func (s *Server) handleStartInstance(w http.ResponseWriter, r *http.Request, ide
 
 		// Refresh state from AWS to get actual current state (pending, running, etc.)
 		updatedInstance = s.refreshInstanceStateFromAWS(awsManager, instanceName)
+		applyExpectedTransitionalState(updatedInstance, "stopped", "pending")
 		return nil
 	})
 
@@ -1075,6 +1096,7 @@ func (s *Server) handleStopInstance(w http.ResponseWriter, r *http.Request, iden
 
 		// Refresh state from AWS to get actual current state (stopping, stopped, etc.)
 		updatedInstance = s.refreshInstanceStateFromAWS(awsManager, instanceName)
+		applyExpectedTransitionalState(updatedInstance, "running", "stopping")
 		return nil
 	})
 
@@ -1117,6 +1139,7 @@ func (s *Server) handleHibernateInstance(w http.ResponseWriter, r *http.Request,
 
 		// Refresh state from AWS to get actual current state (stopping for hibernation)
 		updatedInstance = s.refreshInstanceStateFromAWS(awsManager, instanceName)
+		applyExpectedTransitionalState(updatedInstance, "running", "stopping")
 		return nil
 	})
 
@@ -1159,6 +1182,7 @@ func (s *Server) handleResumeInstance(w http.ResponseWriter, r *http.Request, id
 
 		// Refresh state from AWS to get actual current state (pending, running)
 		updatedInstance = s.refreshInstanceStateFromAWS(awsManager, instanceName)
+		applyExpectedTransitionalState(updatedInstance, "stopped", "pending")
 		return nil
 	})
 


### PR DESCRIPTION
## Summary

- After `StopInstances`/`StartInstances`/etc., AWS `DescribeInstances` may still report the old state for several seconds. The immediate refresh was caching this stale state, so `workspace list` showed "running" even after a successful stop -- requiring users to run the command twice or use `--refresh`.
- Adds `applyExpectedTransitionalState()` helper that sets the expected transitional state (e.g. running->stopping, stopped->pending) when `DescribeInstances` has not caught up yet. Applied to all four lifecycle handlers: stop, start, hibernate, resume.
- No-op when AWS has already reported the transition, so no risk of overwriting a real state.

## Test plan

- [x] New `TestApplyExpectedTransitionalState` unit test (4 subtests: applies state, no-op when caught up, nil safety, start path)
- [x] Existing `TestHandleInstanceActions` and `TestHandleListInstances` pass
- [x] `go vet ./pkg/daemon/` clean
- [ ] Manual: `prism workspace stop <name>` then `prism workspace list` should immediately show STOPPING

🤖 Generated with [Claude Code](https://claude.com/claude-code)