### PR TITLE
fix(cli): correct units in `prism workspace cost` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Prism will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `prism workspace cost` now reports correct lifetime spend and per-minute burn rate. The previous formula treated `instance.CurrentSpend` (lifetime accumulated dollars, per `pkg/types/runtime.go`) as if it were a daily rate, then multiplied it by lifetime fraction --- producing values that differed from `prism workspace list` by orders of magnitude. `TOTAL SPEND` now reads `CurrentSpend` directly; `COST/MIN` derives from `HourlyRate / 60` when running and from the storage-only EBS rate when stopped/hibernated. The institutional-discount path uses the same storage-only rate when stopped, since EBS storage is not subject to compute discounts.
+- `prism workspace cost` `RUNNING` column renamed to `AGE`. The displayed value was wall-clock time since launch, not actual running time. Renamed `CostAnalysis.RunningTime` to `Age` and `formatRunningTime` to `formatAge` for consistency.
+
 ## [0.35.4] - 2026-04-20
 
 ### Documentation
@@ -141,7 +147,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remaining `setState(notifications)` silent drops converted to `toast.*` calls: `onProvision` callback, `EditProjectModal` onSubmit, `EditUserModal` onSubmit, `CreateEFSVolumeModal` (removed `onNotify` prop), `CreateEBSVolumeModal` (same).
 - `WorkshopPage.ts` and `CoursePage.ts` E2E nav selectors scoped to `[data-sidebar="menu-button"]` to prevent strict-mode collision with same-named content-area buttons.
 - `settings.spec.ts` Templates nav selector scoped to sidebar to prevent collision with SettingsView "Template Marketplace" sub-nav button during parallel test runs.
-
 ## [0.31.0] - 2026-04-06
 
 ### Changed

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -484,24 +484,43 @@ type CostCalculationStrategy interface {
 	FormatRow(instance types.Instance, analysis CostAnalysis) string
 }
 
-// CostAnalysis holds the result of cost calculations
+// CostAnalysis holds the result of cost calculations.
+//
+// Field semantics (kept consistent with pkg/types/runtime.go):
+//   - DailyCost / ListDailyCost: cost per day at the instance's running rate (USD/day).
+//   - ActualSpend: lifetime accumulated dollars since launch (USD).
+//   - CurrentCostPerMin / ListCostPerMin: present per-minute burn rate (USD/min).
+//   - Age: wall-clock duration since launch (not actual running time).
 type CostAnalysis struct {
 	DailyCost         float64
 	ListDailyCost     float64
 	ActualSpend       float64
 	CurrentCostPerMin float64
 	ListCostPerMin    float64
-	RunningTime       string
+	Age               string
 	TypeIndicator     string
 	Savings           float64
 	SavingsPercent    float64
+}
+
+// stoppedStorageRatePerMin returns the per-minute storage-only cost for an
+// instance in a non-running state. Mirrors the formula used by
+// printInstanceRow in app.go: $0.005/hr per attached EBS volume, with a
+// minimum of one volume (the root device).
+func stoppedStorageRatePerMin(instance types.Instance) float64 {
+	const ebsHourlyPerVolume = 0.005
+	numEBSVolumes := len(instance.AttachedEBSVolumes)
+	if numEBSVolumes == 0 {
+		numEBSVolumes = 1
+	}
+	return (ebsHourlyPerVolume * float64(numEBSVolumes)) / 60.0
 }
 
 // BasicCostStrategy calculates costs without institutional discounts
 type BasicCostStrategy struct{}
 
 func (b *BasicCostStrategy) CalculateInstanceCost(instance types.Instance, calculator *pricing.Calculator) CostAnalysis {
-	// Calculate total lifetime
+	// Wall-clock lifetime since launch (or until deletion).
 	var totalLifetime time.Duration
 	if !instance.LaunchTime.IsZero() {
 		if instance.DeletionTime != nil && !instance.DeletionTime.IsZero() {
@@ -511,15 +530,20 @@ func (b *BasicCostStrategy) CalculateInstanceCost(instance types.Instance, calcu
 		}
 	}
 
-	dailyCost := instance.CurrentSpend
-	totalMinutes := totalLifetime.Minutes()
-	actualSpend := (dailyCost / (24.0 * 60.0)) * totalMinutes
+	// CurrentSpend is lifetime accumulated dollars (see pkg/types/runtime.go),
+	// not a daily rate. Display it directly as the lifetime total.
+	actualSpend := instance.CurrentSpend
 
+	// dailyCost is what the instance costs per day at its current running rate.
+	dailyCost := instance.HourlyRate * 24.0
+
+	// currentCostPerMin: present burn rate. Compute rate when running;
+	// storage-only rate when stopped/hibernated.
 	var currentCostPerMin float64
 	if instance.State == "running" {
-		currentCostPerMin = dailyCost / (24.0 * 60.0)
+		currentCostPerMin = instance.HourlyRate / 60.0
 	} else {
-		currentCostPerMin = (dailyCost * 0.1) / (24.0 * 60.0) // Storage only
+		currentCostPerMin = stoppedStorageRatePerMin(instance)
 	}
 
 	typeIndicator := "OD"
@@ -533,7 +557,7 @@ func (b *BasicCostStrategy) CalculateInstanceCost(instance types.Instance, calcu
 		ActualSpend:       actualSpend,
 		CurrentCostPerMin: currentCostPerMin,
 		ListCostPerMin:    currentCostPerMin,
-		RunningTime:       b.formatRunningTime(totalLifetime),
+		Age:               b.formatAge(totalLifetime),
 		TypeIndicator:     typeIndicator,
 		Savings:           0,
 		SavingsPercent:    0,
@@ -541,7 +565,7 @@ func (b *BasicCostStrategy) CalculateInstanceCost(instance types.Instance, calcu
 }
 
 func (b *BasicCostStrategy) GetHeaders() []string {
-	return []string{"INSTANCE", "STATE", "TYPE", "RUNNING", "TOTAL SPEND", "COST/MIN"}
+	return []string{"INSTANCE", "STATE", "TYPE", "AGE", "TOTAL SPEND", "COST/MIN"}
 }
 
 func (b *BasicCostStrategy) FormatRow(instance types.Instance, analysis CostAnalysis) string {
@@ -549,12 +573,14 @@ func (b *BasicCostStrategy) FormatRow(instance types.Instance, analysis CostAnal
 		instance.Name,
 		strings.ToUpper(instance.State),
 		analysis.TypeIndicator,
-		analysis.RunningTime,
+		analysis.Age,
 		analysis.ActualSpend,
 		analysis.CurrentCostPerMin)
 }
 
-func (b *BasicCostStrategy) formatRunningTime(duration time.Duration) string {
+// formatAge formats a wall-clock duration since launch as
+// "HH:MM:SS" (under one day) or "D:HH:MM:SS" (one day or more).
+func (b *BasicCostStrategy) formatAge(duration time.Duration) string {
 	days := int(duration.Hours()) / 24
 	hours := int(duration.Hours()) % 24
 	minutes := int(duration.Minutes()) % 60
@@ -572,7 +598,9 @@ type InstitutionalCostStrategy struct{}
 func (i *InstitutionalCostStrategy) CalculateInstanceCost(instance types.Instance, calculator *pricing.Calculator) CostAnalysis {
 	basic := (&BasicCostStrategy{}).CalculateInstanceCost(instance, calculator)
 
-	// Calculate discounted costs if instance type is available
+	// Apply institutional discounts when we have an instance type and a
+	// non-zero hourly rate. basic.DailyCost = HourlyRate * 24, so dividing
+	// by 24 recovers the hourly list price expected by the calculator.
 	if instance.InstanceType != "" && basic.DailyCost > 0 {
 		estimatedHourlyListPrice := basic.DailyCost / 24.0
 		result := calculator.CalculateInstanceCost(instance.InstanceType, estimatedHourlyListPrice, "us-west-2")
@@ -583,9 +611,11 @@ func (i *InstitutionalCostStrategy) CalculateInstanceCost(instance types.Instanc
 			basic.ListCostPerMin = basic.ListDailyCost / (24.0 * 60.0)
 
 			if instance.State == "running" {
+				// Discounted hourly = DailyEstimate / 24, per-minute = / 60.
 				basic.CurrentCostPerMin = basic.DailyCost / (24.0 * 60.0)
 			} else {
-				basic.CurrentCostPerMin = (basic.DailyCost * 0.1) / (24.0 * 60.0)
+				// Discounts apply to compute, not EBS storage; same rate as basic.
+				basic.CurrentCostPerMin = stoppedStorageRatePerMin(instance)
 			}
 
 			basic.Savings = basic.ListCostPerMin - basic.CurrentCostPerMin
@@ -599,7 +629,7 @@ func (i *InstitutionalCostStrategy) CalculateInstanceCost(instance types.Instanc
 }
 
 func (i *InstitutionalCostStrategy) GetHeaders() []string {
-	return []string{"INSTANCE", "STATE", "TYPE", "RUNNING", "TOTAL SPEND", "COST/MIN", "LIST RATE", "SAVINGS"}
+	return []string{"INSTANCE", "STATE", "TYPE", "AGE", "TOTAL SPEND", "COST/MIN", "LIST RATE", "SAVINGS"}
 }
 
 func (i *InstitutionalCostStrategy) FormatRow(instance types.Instance, analysis CostAnalysis) string {
@@ -607,7 +637,7 @@ func (i *InstitutionalCostStrategy) FormatRow(instance types.Instance, analysis 
 		instance.Name,
 		strings.ToUpper(instance.State),
 		analysis.TypeIndicator,
-		analysis.RunningTime,
+		analysis.Age,
 		analysis.ActualSpend,
 		analysis.CurrentCostPerMin,
 		analysis.ListCostPerMin,


### PR DESCRIPTION
## Summary

`prism workspace cost` was displaying values orders of magnitude smaller than `prism workspace list` for the same instance. Root cause: the cost analyzer treated `instance.CurrentSpend` as a daily rate, but the AWS code path populates it as **lifetime accumulated dollars** (see `pkg/types/runtime.go:203` and `pkg/aws/manager.go:calculateActualCosts`).

For an instance that had accumulated \$84.41 of lifetime spend over 33 days, the previous formula computed:

```
actualSpend = (84.41 / 1440) * lifetimeMinutes
```

producing wildly wrong totals.

Rebased on current `main` (v0.35.4). Verified that `CurrentSpend` semantics and the cost-strategy call sites are unchanged on `main`, so the fix is still correct and needed.

## Changes (`internal/cli/commands.go`)

- **`BasicCostStrategy.CalculateInstanceCost`** now reads `CurrentSpend` directly as `ActualSpend`. `DailyCost` derives from `HourlyRate * 24`. `CurrentCostPerMin` is `HourlyRate / 60` when running, storage-only EBS rate when stopped/hibernated (mirrors `printInstanceRow` in `app.go:836-842`).
- **`InstitutionalCostStrategy.CalculateInstanceCost`** uses the same storage-only rate when stopped --- EBS storage is not subject to compute discounts. The running-state rate continues to use the discounted hourly via `result.DailyEstimate / 24`.
- New helper **`stoppedStorageRatePerMin`** avoids duplicating the \$0.005/hr-per-volume formula.
- Renamed **`CostAnalysis.RunningTime` -> `Age`** and **`formatRunningTime` -> `formatAge`**. The displayed value is `time.Since(LaunchTime)` --- wall-clock since launch, not actual running time. Column header changed from `RUNNING` to `AGE`.

The semantic overload of `CurrentSpend` itself (lifetime \$ in the AWS path, daily rate in some mock seed code) is left unchanged here --- a separate refactor candidate.

## Versioning

CHANGELOG entry moved under `[Unreleased]`. Version bump dropped from this PR so the maintainer can roll it into the next release.

## Verification

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `npm run build` | pass |
| `go test ./internal/cli/...` | pass (296s) |
| `go test ./pkg/...` | pass |
| `npm run typecheck` | pass |
| `npm run test:unit` | 286/286 pass |
| `make lint` | pre-existing failures only (misspellings inside `node_modules/`); no new complexity warnings |

## Test plan

- [ ] `./bin/prism workspace cost` against a real (non-test-mode) daemon shows `TOTAL SPEND` matching the `TOTAL $` column in `./bin/prism workspace list` (modulo concurrent state refresh).
- [ ] `./bin/prism workspace cost` shows `AGE` header in place of `RUNNING`.
- [ ] When an instance is stopped, the per-minute cost reflects only attached EBS storage (\$0.005/hr per volume / 60).
- [ ] When an institutional pricing config is loaded, discounted savings still display correctly for running instances.