### PR TITLE
fix(update): stop replaying stale CurrentVersion and use semver compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Prism will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Update checker replays stale `CurrentVersion`**: after a user upgrades, the cached `update_check.json` still held the pre-upgrade version, so `prism` would print `New version available: 0.30.0 -> 0.35.4` even when already on 0.35.4. Cached entries are now re-evaluated against the running binary on read.
+- **Update checker version comparison**: `compareVersions` used raw string ordering, which ranked `0.10.0 < 0.9.0`. Replaced with `golang.org/x/mod/semver`, with explicit guards for `dev`/`unknown`/empty/invalid versions so unreleased builds never trigger an update prompt.
+
 ## [0.35.4] - 2026-04-20
 
 ### Documentation

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/crypto v0.48.0
+	golang.org/x/mod v0.32.0
 	golang.org/x/sys v0.41.0
 	golang.org/x/text v0.34.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/pkg/update/checker.go
+++ b/pkg/update/checker.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/mod/semver"
+
 	"github.com/scttfrdmn/prism/pkg/version"
 )
 
@@ -48,7 +50,14 @@ func NewChecker() (*Checker, error) {
 func (c *Checker) CheckForUpdates(ctx context.Context) (*UpdateInfo, error) {
 	// Try to get cached result first
 	if cached := c.getCachedUpdate(); cached != nil && !cached.IsExpired() {
-		return cached.UpdateInfo, nil
+		// The cache stores the CurrentVersion captured at the time of the
+		// check, but the running binary may have been upgraded since. Recompute
+		// against the actual running version so we don't replay a stale
+		// "0.30.0 -> 0.35.4" notification after the user has already updated.
+		info := *cached.UpdateInfo
+		info.CurrentVersion = version.Version
+		info.IsUpdateAvailable = compareVersions(version.Version, info.LatestVersion)
+		return &info, nil
 	}
 
 	// Fetch latest version from GitHub
@@ -135,15 +144,22 @@ func (c *Checker) fetchLatestVersion(ctx context.Context) (version, url, notes s
 	return version, release.HTMLURL, release.Body, release.PublishedAt, nil
 }
 
-// compareVersions returns true if latest > current
+// compareVersions returns true if latest > current using semver ordering.
+// Dev/unknown current versions are never treated as upgradable, since the user
+// is running an unreleased build and we have no meaningful comparison point.
 func compareVersions(current, latest string) bool {
-	// Strip 'v' prefix if present
 	current = strings.TrimPrefix(current, "v")
 	latest = strings.TrimPrefix(latest, "v")
-
-	// Simple string comparison (works for semantic versioning like "0.6.3" vs "0.7.0")
-	// For production, consider using semver library
-	return latest > current && current != "dev" && current != "unknown"
+	if current == "" || current == "dev" || current == "unknown" {
+		return false
+	}
+	// semver.Compare requires a "v" prefix and treats invalid versions as less
+	// than valid ones, so guard explicitly to avoid false update prompts.
+	cv, lv := "v"+current, "v"+latest
+	if !semver.IsValid(cv) || !semver.IsValid(lv) {
+		return false
+	}
+	return semver.Compare(lv, cv) > 0
 }
 
 // getCachedUpdate retrieves cached update check result

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/prism/pkg/version"
 )
 
 // mockTransport redirects any HTTP request to the provided handler.
@@ -172,16 +174,42 @@ func TestChecker_CheckForUpdates_NewVersion(t *testing.T) {
 }
 
 func TestChecker_CheckForUpdates_UpToDate(t *testing.T) {
-	// Mock returns the same version as current
+	// Mock returns a much lower version than current; semver compare must
+	// recognize the running build is newer and report no update available.
 	c := testChecker(t, releaseHandler("v0.0.1", false, false))
-	// Inject a very low current version to ensure it reads "not available" correctly:
-	// compareVersions returns true when latest > current (string comparison)
-	// We use v0.0.1 which is lower than real version, so IsUpdateAvailable == false
 	info, err := c.CheckForUpdates(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, info)
-	// 0.0.1 <= current version (e.g., 0.21.0) → no update available
 	assert.False(t, info.IsUpdateAvailable)
+}
+
+// TestChecker_CheckForUpdates_StaleCacheRecomputed guards against the
+// "0.30.0 -> 0.35.4" replay bug: after a user upgrades, the cached UpdateInfo
+// still has the old CurrentVersion, but CheckForUpdates must report the
+// actually-running version and re-evaluate IsUpdateAvailable.
+func TestChecker_CheckForUpdates_StaleCacheRecomputed(t *testing.T) {
+	prev := version.Version
+	version.Version = "0.35.4"
+	t.Cleanup(func() { version.Version = prev })
+
+	c := testChecker(t, releaseHandler("v0.35.4", false, false))
+
+	// Pre-populate the cache with a stale entry that was written when the
+	// user was on 0.30.0.
+	stale := &UpdateInfo{
+		CurrentVersion:    "0.30.0",
+		LatestVersion:     "0.35.4",
+		IsUpdateAvailable: true,
+		ReleaseURL:        "https://example.com/v0.35.4",
+		LastChecked:       time.Now(),
+	}
+	c.cacheUpdate(stale)
+
+	info, err := c.CheckForUpdates(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "0.35.4", info.CurrentVersion, "should reflect running binary, not cached value")
+	assert.False(t, info.IsUpdateAvailable, "0.35.4 == 0.35.4 means no update")
 }
 
 func TestChecker_CheckForUpdates_NetworkError(t *testing.T) {
@@ -213,6 +241,35 @@ func TestChecker_CheckForUpdates_Prerelease_Skipped(t *testing.T) {
 	_, err := c.CheckForUpdates(context.Background())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "prerelease")
+}
+
+// ── compareVersions ───────────────────────────────────────────────────────
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+		name            string
+	}{
+		// Bug #N: raw string comparison reported "0.10.0" < "0.9.0" because
+		// '1' < '9' lexicographically. semver compare must order by number.
+		{"0.9.0", "0.10.0", true, "minor digit boundary"},
+		{"0.10.0", "0.9.0", false, "minor digit boundary reversed"},
+		{"0.99.0", "0.100.0", true, "two-digit to three-digit minor"},
+		{"1.0.0", "2.0.0", true, "major bump"},
+		{"0.35.4", "0.35.4", false, "equal"},
+		{"0.35.4", "0.35.3", false, "older latest"},
+		{"v0.35.4", "v0.35.5", true, "with v prefix"},
+		{"dev", "99.0.0", false, "dev never updates"},
+		{"unknown", "99.0.0", false, "unknown never updates"},
+		{"", "1.0.0", false, "empty current"},
+		{"garbage", "1.0.0", false, "invalid current rejected"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, compareVersions(tc.current, tc.latest))
+		})
+	}
 }
 
 // ── ClearCache ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two bugs in the update notifier conspire to print misleading messages like:

```
prism --version
> Prism CLI v0.35.4 ...
prism workspace list
> 💡 New version available: 0.30.0 → 0.35.4. Run: git pull && make build
```

after a user has already upgraded.

- **Stale cache replay** (`pkg/update/checker.go`): `CheckForUpdates` returned the cached `UpdateInfo` verbatim within the 24h TTL. The on-disk cache stores `CurrentVersion` at the time of the previous check, so after the user rebuilds, the cached value is wrong but is still displayed. Fix: overlay `version.Version` onto the cached info on read and recompute `IsUpdateAvailable`.
- **Lexicographic version compare**: `compareVersions` did `latest > current` on raw strings, which ranks `0.10.0 < 0.9.0`. Latent today, will bite when the minor crosses a digit boundary. Replaced with `golang.org/x/mod/semver`, keeping explicit guards for `dev` / `unknown` / empty / invalid so unreleased builds never trigger an update prompt.

`golang.org/x/mod` was already in `go.sum` as a transitive dep; this change promotes it to a direct dep — no new module added.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./pkg/update/...` — clean
- [x] `gofmt`, `goimports`, `misspell` on changed files — clean
- [x] `go test ./pkg/update/... -v` — all pass, including new tests:
  - `TestChecker_CheckForUpdates_StaleCacheRecomputed` — pre-populates cache with stale `CurrentVersion`, asserts result reflects running binary
  - `TestCompareVersions` — table covers the `0.9.0` vs `0.10.0` boundary, plus dev/unknown/empty/invalid guards
- [ ] Manual: rebuild, blow away `~/.prism/cache/update_check.json`, run `prism workspace list` — no spurious notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)