### PR TITLE
feat(cost): add 'prism workspace cost --billed' for AWS-billed cost from Cost Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `prism workspace cost --billed [name]` reports the AWS-billed ("billed so far") cost from AWS Cost Explorer next to prism's local estimate and the delta between them. prism's existing cost numbers are a model the daemon accumulates from observed state transitions (`Instance.CurrentSpend`); the billed figure is the metered amount AWS has actually charged, read via `ce:GetCostAndUsage` using the UnblendedCost metric. This surfaces drift between the two --- for example, the same workspace controlled from two machines can report different local estimates while AWS bills one number. Per-instance isolation uses the `prism:instance-id` cost-allocation tag when it is activated in the Billing console; when the tag is inactive, the command falls back to the region's EC2 total and warns that it may include other instances. `--billed-only` shows just the AWS figure. New daemon endpoint `GET /api/v1/instances/{name}/billed-cost`. Requires the daemon's AWS identity to hold the `ce:GetCostAndUsage` permission; access-denied errors include the fix.
 - **The persistence seam (`pkg/seam`)** — the shared record/persistence + identity interface
   Prism's governance managers converge onto (the prism-research-portal design §5). `Principal` /
   `Scope` (tenant/project/pi/grant + account) and a generic, scoped `Store[T]` repository, with a

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1006,6 +1006,119 @@ func (a *App) ListCost(args []string) error {
 	return nil
 }
 
+// ListBilledCost shows the AWS-billed ("billed so far") cost for workspaces,
+// read from AWS Cost Explorer, next to prism's local estimate (CurrentSpend).
+// The estimate is a model accumulated by the daemon; the billed figure is the
+// metered amount AWS has charged. When name is non-empty it scopes to one
+// workspace; billedOnly drops the estimate and delta columns.
+func (a *App) ListBilledCost(name, projectFilter string, billedOnly bool) error {
+	if err := a.ensureDaemonRunning(); err != nil {
+		return err
+	}
+
+	response, err := a.apiClient.ListInstances(a.ctx)
+	if err != nil {
+		return WrapAPIError("list workspaces for cost analysis", err)
+	}
+
+	var instances []types.Instance
+	for _, inst := range response.Instances {
+		if name != "" && inst.Name != name {
+			continue
+		}
+		if projectFilter != "" && inst.ProjectID != projectFilter {
+			continue
+		}
+		instances = append(instances, inst)
+	}
+
+	if len(instances) == 0 {
+		switch {
+		case name != "":
+			fmt.Printf("Workspace '%s' not found.\n", name)
+		case projectFilter != "":
+			fmt.Printf("No workstations found in project '%s'.\n", projectFilter)
+		default:
+			fmt.Println("No workstations found.")
+		}
+		return nil
+	}
+
+	fmt.Println("💰 Prism Billed Cost (AWS Cost Explorer)")
+	fmt.Println()
+
+	w := tabwriter.NewWriter(os.Stdout, TabWriterMinWidth, TabWriterTabWidth, TabWriterPadding, TabWriterPadChar, TabWriterFlags)
+	if billedOnly {
+		_, _ = fmt.Fprintln(w, "INSTANCE\tSTATE\tBILLED SO FAR")
+	} else {
+		_, _ = fmt.Fprintln(w, "INSTANCE\tSTATE\tBILLED SO FAR\tPRISM EST\tDELTA")
+	}
+
+	var notes []string
+	var sourceLine string
+	var anyTagInactive, anyEstimated bool
+	for _, inst := range instances {
+		billed, err := a.apiClient.GetBilledCost(a.ctx, inst.Name)
+		if err != nil {
+			if billedOnly {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", inst.Name, strings.ToUpper(inst.State), "error")
+			} else {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t$%.4f\t%s\n",
+					inst.Name, strings.ToUpper(inst.State), "error", inst.CurrentSpend, "n/a")
+			}
+			notes = append(notes, fmt.Sprintf("%s: %v", inst.Name, err))
+			continue
+		}
+
+		if sourceLine == "" {
+			sourceLine = billed.Source
+		}
+		marker := ""
+		if !billed.TagActive {
+			marker += "*"
+			anyTagInactive = true
+		}
+		if billed.Estimated {
+			marker += "~"
+			anyEstimated = true
+		}
+
+		if billedOnly {
+			_, _ = fmt.Fprintf(w, "%s\t%s\t$%.4f%s\n",
+				inst.Name, strings.ToUpper(inst.State), billed.BilledTotal, marker)
+		} else {
+			// DELTA = prism estimate minus AWS billed; positive means prism over-counts.
+			delta := inst.CurrentSpend - billed.BilledTotal
+			_, _ = fmt.Fprintf(w, "%s\t%s\t$%.4f%s\t$%.4f\t%+.4f\n",
+				inst.Name, strings.ToUpper(inst.State), billed.BilledTotal, marker, inst.CurrentSpend, delta)
+		}
+
+		if billed.Note != "" {
+			notes = append(notes, fmt.Sprintf("%s: %s", inst.Name, billed.Note))
+		}
+	}
+	_ = w.Flush()
+
+	fmt.Println()
+	if sourceLine != "" {
+		fmt.Printf("Source: %s\n", sourceLine)
+	}
+	if !billedOnly {
+		fmt.Println("DELTA = prism estimate minus AWS billed (positive means prism over-counts).")
+	}
+	if anyTagInactive {
+		fmt.Println("* region fallback: per-instance cost-allocation tag not active.")
+	}
+	if anyEstimated {
+		fmt.Println("~ includes a current period AWS has not yet finalized.")
+	}
+	for _, n := range notes {
+		fmt.Printf("  - %s\n", n)
+	}
+
+	return nil
+}
+
 func (a *App) Connect(args []string) error {
 	return a.instanceCommands.Connect(args)
 }

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -288,6 +288,55 @@ func TestListCostCommand(t *testing.T) {
 	}
 }
 
+func TestListBilledCostCommand(t *testing.T) {
+	t.Run("reconcile view shows billed, estimate, and delta", func(t *testing.T) {
+		mock := NewMockAPIClient()
+		// Give the workspace a known local estimate; the mock returns the same
+		// value as billed, so the delta should be zero.
+		for i := range mock.Instances {
+			if mock.Instances[i].Name == "test-instance" {
+				mock.Instances[i].CurrentSpend = 42.50
+			}
+		}
+		app := NewAppWithClient("1.0.0", mock)
+
+		out := captureStdout(t, func() {
+			require.NoError(t, app.ListBilledCost("test-instance", "", false))
+		})
+
+		assert.Contains(t, out, "BILLED SO FAR")
+		assert.Contains(t, out, "PRISM EST")
+		assert.Contains(t, out, "DELTA")
+		assert.Contains(t, out, "test-instance")
+		assert.Contains(t, out, "$42.5000")
+		assert.Contains(t, out, "+0.0000") // billed == estimate in the mock
+	})
+
+	t.Run("billed-only hides estimate and delta columns", func(t *testing.T) {
+		mock := NewMockAPIClient()
+		app := NewAppWithClient("1.0.0", mock)
+
+		out := captureStdout(t, func() {
+			require.NoError(t, app.ListBilledCost("test-instance", "", true))
+		})
+
+		assert.Contains(t, out, "BILLED SO FAR")
+		assert.NotContains(t, out, "PRISM EST")
+		assert.NotContains(t, out, "DELTA")
+	})
+
+	t.Run("unknown workspace name reports not found", func(t *testing.T) {
+		mock := NewMockAPIClient()
+		app := NewAppWithClient("1.0.0", mock)
+
+		out := captureStdout(t, func() {
+			require.NoError(t, app.ListBilledCost("does-not-exist", "", false))
+		})
+
+		assert.Contains(t, out, "not found")
+	})
+}
+
 // TestConnectCommandIntegration tests the connect command delegation
 func TestConnectCommandIntegration(t *testing.T) {
 	mockClient := NewMockAPIClient()

--- a/internal/cli/mock_api_client.go
+++ b/internal/cli/mock_api_client.go
@@ -260,6 +260,28 @@ func (m *MockAPIClient) GetInstance(ctx context.Context, name string) (*types.In
 	return nil, fmt.Errorf("instance %s not found", name)
 }
 
+// GetBilledCost returns mock AWS-billed cost for an instance.
+func (m *MockAPIClient) GetBilledCost(ctx context.Context, name string) (*types.BilledCostResult, error) {
+	if m.ShouldReturnError {
+		return nil, fmt.Errorf("%s", m.ErrorMessage)
+	}
+
+	for _, instance := range m.Instances {
+		if instance.Name == name {
+			return &types.BilledCostResult{
+				Name:        name,
+				BilledTotal: instance.CurrentSpend,
+				Currency:    "USD",
+				Region:      instance.Region,
+				Source:      "mock",
+				TagActive:   true,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("instance %s not found", name)
+}
+
 // GetProgress returns mock progress for an instance (v0.7.2 - Issue #453)
 func (m *MockAPIClient) GetProgress(ctx context.Context, name string) (*types.ProgressResponse, error) {
 	if m.ShouldReturnError {

--- a/internal/cli/workspace_commands.go
+++ b/internal/cli/workspace_commands.go
@@ -154,19 +154,42 @@ func (f *WorkspaceCommandFactory) createListCommand() *cobra.Command {
 
 func (f *WorkspaceCommandFactory) createCostCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cost",
-		Short: "Detailed cost breakdown with savings analysis",
-		Long: `Show detailed cost analysis for all workspaces, including running time,
-per-minute costs, monthly estimates, and institutional discount savings.`,
+		Use:   "cost [name]",
+		Short: "Cost breakdown (local estimate, or AWS-billed with --billed)",
+		Long: `Show cost analysis for workspaces.
+
+By default this shows prism's local estimate: per-minute burn rate, monthly
+projection, and institutional discount savings.
+
+Use --billed to show the AWS-billed "billed so far" cost from AWS Cost
+Explorer -- the authoritative meter -- next to prism's estimate and the delta
+between them. The estimate is a model the daemon accumulates locally; the
+billed figure is what AWS has actually charged, so the two can diverge. Pass a
+workspace name to scope to one.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			project, _ := cmd.Flags().GetString("project")
+			billed, _ := cmd.Flags().GetBool("billed")
+			billedOnly, _ := cmd.Flags().GetBool("billed-only")
+
+			if billed || billedOnly {
+				var name string
+				if len(args) == 1 {
+					name = args[0]
+				}
+				return f.app.ListBilledCost(name, project, billedOnly)
+			}
+
 			var flagArgs []string
-			if project, _ := cmd.Flags().GetString("project"); project != "" {
+			if project != "" {
 				flagArgs = append(flagArgs, "--project", project)
 			}
 			return f.app.ListCost(flagArgs)
 		},
 	}
 	cmd.Flags().String("project", "", "Filter by project ID")
+	cmd.Flags().Bool("billed", false, "Show AWS-billed cost from Cost Explorer alongside prism's estimate")
+	cmd.Flags().Bool("billed-only", false, "Show only the AWS-billed cost (implies --billed; hides estimate/delta)")
 	return cmd
 }
 

--- a/pkg/api/client/http_client.go
+++ b/pkg/api/client/http_client.go
@@ -262,6 +262,23 @@ func (c *HTTPClient) GetInstance(ctx context.Context, name string) (*types.Insta
 	return &result, nil
 }
 
+// GetBilledCost returns the AWS-billed ("billed so far") cost for a workspace,
+// sourced from AWS Cost Explorer rather than prism's local estimate.
+func (c *HTTPClient) GetBilledCost(ctx context.Context, name string) (*types.BilledCostResult, error) {
+	resp, err := c.makeRequest(ctx, "GET", fmt.Sprintf("/api/v1/instances/%s/billed-cost", name), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result types.BilledCostResult
+	if err := c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // GetProgress returns the current setup progress for an instance (v0.7.2 - Issue #453)
 func (c *HTTPClient) GetProgress(ctx context.Context, name string) (*types.ProgressResponse, error) {
 	resp, err := c.makeRequest(ctx, "GET", fmt.Sprintf("/api/v1/instances/%s/progress", name), nil)

--- a/pkg/api/client/interface.go
+++ b/pkg/api/client/interface.go
@@ -33,7 +33,8 @@ type PrismAPI interface {
 	ListInstances(context.Context) (*types.ListResponse, error)
 	ListInstancesWithRefresh(context.Context, bool) (*types.ListResponse, error)
 	GetInstance(context.Context, string) (*types.Instance, error)
-	GetProgress(context.Context, string) (*types.ProgressResponse, error) // Launch progress (v0.7.2)
+	GetProgress(context.Context, string) (*types.ProgressResponse, error)   // Launch progress (v0.7.2)
+	GetBilledCost(context.Context, string) (*types.BilledCostResult, error) // AWS-billed cost from Cost Explorer
 	StartInstance(context.Context, string) error
 	StopInstance(context.Context, string) error
 	HibernateInstance(context.Context, string) error

--- a/pkg/api/client/mock.go
+++ b/pkg/api/client/mock.go
@@ -88,6 +88,20 @@ func (m *MockClient) GetInstance(ctx context.Context, name string) (*types.Insta
 	return nil, fmt.Errorf("instance not found: %s", name)
 }
 
+func (m *MockClient) GetBilledCost(ctx context.Context, name string) (*types.BilledCostResult, error) {
+	if instance, exists := m.instances[name]; exists {
+		return &types.BilledCostResult{
+			Name:        name,
+			BilledTotal: instance.CurrentSpend,
+			Currency:    "USD",
+			Region:      instance.Region,
+			Source:      "mock",
+			TagActive:   true,
+		}, nil
+	}
+	return nil, fmt.Errorf("instance not found: %s", name)
+}
+
 func (m *MockClient) StartInstance(ctx context.Context, name string) error {
 	if instance, exists := m.instances[name]; exists {
 		instance.State = "running"

--- a/pkg/api/mock/mock_client.go
+++ b/pkg/api/mock/mock_client.go
@@ -395,6 +395,22 @@ func (m *MockClient) GetInstance(ctx context.Context, name string) (*types.Insta
 	return nil, fmt.Errorf("instance not found: %s", name)
 }
 
+// GetBilledCost returns mock AWS-billed cost for an instance.
+func (m *MockClient) GetBilledCost(ctx context.Context, name string) (*types.BilledCostResult, error) {
+	instance, exists := m.Instances[name]
+	if !exists {
+		return nil, fmt.Errorf("instance not found: %s", name)
+	}
+	return &types.BilledCostResult{
+		Name:        name,
+		BilledTotal: instance.CurrentSpend,
+		Currency:    "USD",
+		Region:      instance.Region,
+		Source:      "mock",
+		TagActive:   true,
+	}, nil
+}
+
 // GetProgress returns mock progress for an instance (v0.7.2 - Issue #453)
 func (m *MockClient) GetProgress(ctx context.Context, name string) (*types.ProgressResponse, error) {
 	if _, exists := m.Instances[name]; !exists {

--- a/pkg/aws/billed_cost.go
+++ b/pkg/aws/billed_cost.go
@@ -1,0 +1,167 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+	ctypes "github.com/scttfrdmn/prism/pkg/types"
+)
+
+// costAllocationTagKey is the AWS cost-allocation tag prism stamps on every
+// managed instance (value == workspace name). For per-instance billed cost it
+// must be ACTIVATED in the payer account's Billing console, and activation is
+// not retroactive: cost before activation is not attributed to the tag.
+const costAllocationTagKey = "prism:instance-id"
+
+// GetBilledCost returns the AWS-billed cost for one workspace over [since, now],
+// read from AWS Cost Explorer using the UnblendedCost metric. This is the
+// metered "billed so far" amount AWS has charged, not prism's local estimate
+// (Instance.CurrentSpend).
+//
+// Cost Explorer is a global service reached through a single endpoint, so the
+// client is pinned to us-east-1 regardless of the workspace's region; the
+// region is applied as a filter dimension instead.
+//
+// Isolation strategy: query first by the prism cost-allocation tag (exact, when
+// the tag is activated). If that returns nothing -- the common case when the
+// tag has not been activated in Billing -- fall back to the region's EC2 total
+// and label the result so the caller can warn that it may include other
+// instances.
+func (m *Manager) GetBilledCost(ctx context.Context, name, region string, since time.Time) (*ctypes.BilledCostResult, error) {
+	ce := costexplorer.NewFromConfig(m.cfg, func(o *costexplorer.Options) {
+		o.Region = "us-east-1"
+	})
+
+	// Cost Explorer's end date is exclusive; end tomorrow to include today.
+	start := since.UTC().Format("2006-01-02")
+	if since.IsZero() {
+		start = time.Now().UTC().AddDate(-1, 0, 0).Format("2006-01-02")
+	}
+	end := time.Now().UTC().AddDate(0, 0, 1).Format("2006-01-02")
+
+	result := &ctypes.BilledCostResult{
+		Name:     name,
+		Currency: "USD",
+		Start:    start,
+		End:      end,
+		Region:   region,
+		Source:   "AWS Cost Explorer (UnblendedCost)",
+	}
+
+	// Primary: isolate this instance by its prism cost-allocation tag.
+	tagged, err := m.queryBilled(ctx, ce, start, end, &cetypes.Expression{
+		Tags: &cetypes.TagValues{
+			Key:    aws.String(costAllocationTagKey),
+			Values: []string{name},
+		},
+	})
+	if err != nil {
+		return nil, wrapBilledCostErr(err)
+	}
+	if tagged.total > 0 {
+		result.TagActive = true
+		result.BilledTotal = tagged.total
+		result.Monthly = tagged.periods
+		result.Estimated = tagged.estimated
+		return result, nil
+	}
+
+	// Fallback: tag not activated (or no spend yet). Report the region's EC2
+	// total, clearly labeled as possibly including other instances.
+	regionRes, err := m.queryBilled(ctx, ce, start, end, &cetypes.Expression{
+		And: []cetypes.Expression{
+			{Dimensions: &cetypes.DimensionValues{
+				Key:    cetypes.DimensionRegion,
+				Values: []string{region},
+			}},
+			{Dimensions: &cetypes.DimensionValues{
+				Key: cetypes.DimensionService,
+				Values: []string{
+					"Amazon Elastic Compute Cloud - Compute",
+					"EC2 - Other",
+				},
+			}},
+		},
+	})
+	if err != nil {
+		return nil, wrapBilledCostErr(err)
+	}
+	result.TagActive = false
+	result.BilledTotal = regionRes.total
+	result.FallbackRegionTotal = regionRes.total
+	result.Monthly = regionRes.periods
+	result.Estimated = regionRes.estimated
+	result.Note = fmt.Sprintf(
+		"cost-allocation tag %q is not active, so this is the EC2 total for region %s and may include other instances. Activate the tag in the AWS Billing console (Cost Allocation Tags) for exact per-instance cost; activation is not retroactive.",
+		costAllocationTagKey, region)
+	return result, nil
+}
+
+type billedQueryResult struct {
+	total     float64
+	estimated bool
+	periods   []ctypes.BilledCostPeriod
+}
+
+func (m *Manager) queryBilled(ctx context.Context, ce *costexplorer.Client, start, end string, filter *cetypes.Expression) (*billedQueryResult, error) {
+	out, err := ce.GetCostAndUsage(ctx, &costexplorer.GetCostAndUsageInput{
+		TimePeriod: &cetypes.DateInterval{
+			Start: aws.String(start),
+			End:   aws.String(end),
+		},
+		Granularity: cetypes.GranularityMonthly,
+		Metrics:     []string{"UnblendedCost"},
+		Filter:      filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return summarizeBilled(out.ResultsByTime), nil
+}
+
+// summarizeBilled reduces Cost Explorer's per-period results into a single
+// billedQueryResult: the UnblendedCost summed across periods, each period
+// preserved, and estimated set if any period is still AWS-estimated. It is a
+// pure function of the API response so it can be unit-tested without AWS.
+func summarizeBilled(results []cetypes.ResultByTime) *billedQueryResult {
+	res := &billedQueryResult{}
+	for _, period := range results {
+		amount := 0.0
+		if metric, ok := period.Total["UnblendedCost"]; ok && metric.Amount != nil {
+			// Amount arrives as a decimal string, e.g. "70.1414001792".
+			fmt.Sscanf(*metric.Amount, "%f", &amount)
+		}
+		res.total += amount
+		if period.Estimated {
+			res.estimated = true
+		}
+		p := ctypes.BilledCostPeriod{Amount: amount, Estimated: period.Estimated}
+		if period.TimePeriod != nil {
+			if period.TimePeriod.Start != nil {
+				p.Start = *period.TimePeriod.Start
+			}
+			if period.TimePeriod.End != nil {
+				p.End = *period.TimePeriod.End
+			}
+		}
+		res.periods = append(res.periods, p)
+	}
+	return res
+}
+
+// wrapBilledCostErr adds an actionable hint when Cost Explorer denies access,
+// the most common failure (the daemon's AWS identity lacks ce:GetCostAndUsage).
+func wrapBilledCostErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "AccessDenied") || strings.Contains(err.Error(), "not authorized") {
+		return fmt.Errorf("AWS Cost Explorer access denied -- the daemon's AWS identity needs the ce:GetCostAndUsage permission (and Cost Explorer must be enabled once in the Billing console): %w", err)
+	}
+	return fmt.Errorf("cost explorer query failed: %w", err)
+}

--- a/pkg/aws/billed_cost_test.go
+++ b/pkg/aws/billed_cost_test.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+)
+
+func ceResult(start, end, amount string, estimated bool) cetypes.ResultByTime {
+	return cetypes.ResultByTime{
+		Estimated: estimated,
+		TimePeriod: &cetypes.DateInterval{
+			Start: aws.String(start),
+			End:   aws.String(end),
+		},
+		Total: map[string]cetypes.MetricValue{
+			"UnblendedCost": {Amount: aws.String(amount), Unit: aws.String("USD")},
+		},
+	}
+}
+
+func TestSummarizeBilled_SumsAcrossPeriods(t *testing.T) {
+	// Mirrors the real bristol-workspace lifetime: Mar..Jun, last period estimated.
+	results := []cetypes.ResultByTime{
+		ceResult("2026-03-01", "2026-04-01", "11.5467688704", false),
+		ceResult("2026-04-01", "2026-05-01", "45.8914960224", false),
+		ceResult("2026-05-01", "2026-06-01", "70.1414001792", false),
+		ceResult("2026-06-01", "2026-06-04", "8.8707360672", true),
+	}
+
+	got := summarizeBilled(results)
+
+	const want = 136.4504011392
+	if diff := got.total - want; diff > 1e-6 || diff < -1e-6 {
+		t.Errorf("total = %.10f, want %.10f", got.total, want)
+	}
+	if !got.estimated {
+		t.Error("estimated = false, want true (last period is AWS-estimated)")
+	}
+	if len(got.periods) != 4 {
+		t.Fatalf("periods = %d, want 4", len(got.periods))
+	}
+	if got.periods[3].Start != "2026-06-01" || !got.periods[3].Estimated {
+		t.Errorf("last period = %+v, want start 2026-06-01 and estimated", got.periods[3])
+	}
+}
+
+func TestSummarizeBilled_EmptyAndMissingMetric(t *testing.T) {
+	// No results -> zero, not estimated.
+	if got := summarizeBilled(nil); got.total != 0 || got.estimated || len(got.periods) != 0 {
+		t.Errorf("empty summarize = %+v, want zero/false/0-periods", got)
+	}
+
+	// A period with no UnblendedCost metric contributes zero, not a panic.
+	results := []cetypes.ResultByTime{
+		{TimePeriod: &cetypes.DateInterval{Start: aws.String("2026-05-01"), End: aws.String("2026-06-01")}},
+	}
+	got := summarizeBilled(results)
+	if got.total != 0 {
+		t.Errorf("total = %v, want 0 when metric absent", got.total)
+	}
+	if len(got.periods) != 1 || got.periods[0].Amount != 0 {
+		t.Errorf("periods = %+v, want one zero-amount period", got.periods)
+	}
+}
+
+func TestWrapBilledCostErr_AccessDeniedHint(t *testing.T) {
+	if wrapBilledCostErr(nil) != nil {
+		t.Error("wrapBilledCostErr(nil) should be nil")
+	}
+
+	denied := wrapBilledCostErr(errString("AccessDeniedException: user is not authorized to perform ce:GetCostAndUsage"))
+	if denied == nil || !containsAll(denied.Error(), "ce:GetCostAndUsage", "Billing console") {
+		t.Errorf("access-denied error missing hint: %v", denied)
+	}
+
+	other := wrapBilledCostErr(errString("boom"))
+	if other == nil || !containsAll(other.Error(), "cost explorer query failed") {
+		t.Errorf("generic error not wrapped: %v", other)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/daemon/billed_cost_handlers.go
+++ b/pkg/daemon/billed_cost_handlers.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"net/http"
+
+	"github.com/scttfrdmn/prism/pkg/aws"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// handleBilledCost serves GET /api/v1/instances/{name}/billed-cost.
+//
+// It returns the AWS-billed ("billed so far") cost for the workspace from AWS
+// Cost Explorer -- the authoritative meter -- rather than prism's local
+// estimate (Instance.CurrentSpend). The two can diverge; the CLI shows both.
+func (s *Server) handleBilledCost(w http.ResponseWriter, r *http.Request, identifier string) {
+	if r.Method != http.MethodGet {
+		s.writeError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	instanceName, found := s.resolveInstanceIdentifier(identifier)
+	if !found {
+		s.writeError(w, http.StatusNotFound, "Instance not found")
+		return
+	}
+
+	state, err := s.stateManager.LoadState()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "Failed to load state")
+		return
+	}
+	cached, exists := state.Instances[instanceName]
+	if !exists {
+		s.writeError(w, http.StatusNotFound, "Instance not found in state")
+		return
+	}
+
+	// Test mode: return synthetic data and never call AWS, so E2E runs do not
+	// block on Cost Explorer (see CLAUDE.md test-mode contract).
+	if s.testMode {
+		s.writeJSON(w, http.StatusOK, syntheticBilledCost(cached))
+		return
+	}
+
+	var result *types.BilledCostResult
+	s.withAWSManager(w, r, func(awsManager *aws.Manager) error {
+		var qerr error
+		result, qerr = awsManager.GetBilledCost(r.Context(), instanceName, cached.Region, cached.LaunchTime)
+		return qerr
+	})
+	if result == nil {
+		// withAWSManager already wrote an error response.
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, result)
+}
+
+// syntheticBilledCost returns deterministic billed-cost data for test mode.
+// It echoes the instance's locally-estimated spend so reconciliation renders a
+// zero delta, which keeps E2E assertions stable.
+func syntheticBilledCost(inst types.Instance) types.BilledCostResult {
+	return types.BilledCostResult{
+		Name:        inst.Name,
+		BilledTotal: inst.CurrentSpend,
+		Currency:    "USD",
+		Region:      inst.Region,
+		Source:      "synthetic (PRISM_TEST_MODE)",
+		TagActive:   true,
+	}
+}

--- a/pkg/daemon/instance_handlers.go
+++ b/pkg/daemon/instance_handlers.go
@@ -738,6 +738,7 @@ func (s *Server) handleInstanceSubOperation(w http.ResponseWriter, r *http.Reque
 		"progress":              s.handleGetProgress,      // Launch progress monitoring (v0.7.2 - Issue #453)
 		"files":                 s.handleInstanceFiles,    // SSM file ops (#30)
 		"s3-mounts":             s.handleInstanceS3Mounts, // S3 mount ops (#22)
+		"billed-cost":           s.handleBilledCost,       // AWS-billed cost from Cost Explorer
 	}
 
 	if handler, exists := operationHandlers[operation]; exists {

--- a/pkg/types/runtime.go
+++ b/pkg/types/runtime.go
@@ -254,6 +254,40 @@ type StateTransition struct {
 	Initiator string    `json:"initiator,omitempty"` // Who/what initiated (user, system, policy)
 }
 
+// BilledCostPeriod is one time bucket of AWS-billed cost, read from AWS Cost
+// Explorer. Estimated is true when AWS has not yet finalized the period (the
+// current, still-accruing month).
+type BilledCostPeriod struct {
+	Start     string  `json:"start"`  // inclusive, YYYY-MM-DD
+	End       string  `json:"end"`    // exclusive, YYYY-MM-DD
+	Amount    float64 `json:"amount"` // UnblendedCost for the period
+	Estimated bool    `json:"estimated"`
+}
+
+// BilledCostResult is the AWS-billed ("billed so far") cost for one workspace.
+// It comes from AWS Cost Explorer (the meter), not from prism's local
+// CurrentSpend accumulator (the model). The two can diverge: see the cost
+// command's reconciliation view.
+//
+// Per-instance isolation relies on an activated cost-allocation tag. When the
+// tag is not active, TagActive is false and BilledTotal falls back to the
+// region's EC2 total (FallbackRegionTotal), which may include other instances;
+// Note then explains the limitation.
+type BilledCostResult struct {
+	Name                string             `json:"name"`
+	BilledTotal         float64            `json:"billed_total"`
+	Currency            string             `json:"currency"`
+	Monthly             []BilledCostPeriod `json:"monthly"`
+	Start               string             `json:"start"` // window start, YYYY-MM-DD
+	End                 string             `json:"end"`   // window end (exclusive), YYYY-MM-DD
+	Region              string             `json:"region"`
+	Source              string             `json:"source"`     // e.g. "AWS Cost Explorer (UnblendedCost)"
+	TagActive           bool               `json:"tag_active"` // whether per-instance tag isolation worked
+	FallbackRegionTotal float64            `json:"fallback_region_total,omitempty"`
+	Estimated           bool               `json:"estimated"` // any period still AWS-estimated
+	Note                string             `json:"note,omitempty"`
+}
+
 // IdleDetection represents idle detection configuration for an instance
 type IdleDetection struct {
 	Enabled        bool      `json:"enabled"`


### PR DESCRIPTION
## Motivation

`prism workspace cost` reports a **local estimate**: the daemon accumulates `Instance.CurrentSpend` from observed state transitions and a stored hourly rate. That model drifts from what AWS actually bills. Concretely, the same workspace (`i-...`, one EC2 instance) driven from two machines reported very different cost, because each machine keeps its own `~/.prism/state.json` with an independent launch time, accumulated spend, and -- on one machine -- a wrong hourly rate (a fallback estimate of \$0.80/hr for an `m7i.xlarge` whose real price is \$0.2016/hr). prism had no way to show the authoritative number.

## What this adds

A "billed so far" view sourced from **AWS Cost Explorer** (the meter), shown next to prism's estimate so drift is obvious.

```
$ prism workspace cost --billed
💰 Prism Billed Cost (AWS Cost Explorer)

INSTANCE           STATE    BILLED SO FAR  PRISM EST   DELTA
bristol-workspace  RUNNING  $136.4504      $183.7361   +47.2857

Source: AWS Cost Explorer (UnblendedCost)
DELTA = prism estimate minus AWS billed (positive means prism over-counts).
```

- **Daemon**: `GET /api/v1/instances/{name}/billed-cost` queries Cost Explorer with the `UnblendedCost` metric over `[launch, now]`. The Cost Explorer client is pinned to `us-east-1` (its global endpoint).
- **Isolation**: filters by the `prism:instance-id` cost-allocation tag. AWS cost-allocation tags must be **activated** in the Billing console and are **not retroactive**, so when the tag returns nothing the command falls back to the region's EC2 total and prints a warning that it may include other instances. (Resource-level granularity -- the exact per-instance path -- is an opt-in billing feature and out of scope here.)
- **CLI**: `prism workspace cost --billed [name]` reconciles billed vs estimate and shows the delta. `--billed-only` shows just the AWS figure. Optional positional name scopes to one workspace.
- **Permissions**: requires the daemon's AWS identity to hold `ce:GetCostAndUsage`. Access-denied errors carry the fix in their message (this was the failure on the second machine).
- **Test mode**: `PRISM_TEST_MODE=true` returns synthetic data and never calls AWS, per the E2E contract.

## Tests

- `pkg/aws`: `summarizeBilled` aggregation (sum across periods, estimated propagation, empty/missing-metric handling) and the access-denied hint wrapper.
- `internal/cli`: billed-vs-estimate reconciliation rendering, `--billed-only` column hiding, and the unknown-workspace path.

## Quality gates

- `go build ./...` clean
- `go vet ./...` clean
- `gofmt` clean
- `go test ./pkg/types/... ./pkg/aws/ ./pkg/api/... ./internal/cli/` pass

## Notes / follow-ups

- Versioned under `## [Unreleased]` in `CHANGELOG.md`; no version bump (left for a release commit).
- One Cost Explorer call per workspace (two if it falls back); fine for a handful of workspaces. A single tag-grouped call could batch this later.
- GUI (`SafePrismAPI`) not wired yet -- the daemon endpoint is ready for it.
- The reused `costexplorer` SDK is already a dependency (`pkg/storage/analytics_manager.go`); no new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)