### PR TITLE
release: v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-07-07
+
 ### Added
 - `prism workspace cost --billed [name]` reports the AWS-billed ("billed so far") cost from AWS Cost Explorer next to prism's local estimate and the delta between them. prism's existing cost numbers are a model the daemon accumulates from observed state transitions (`Instance.CurrentSpend`); the billed figure is the metered amount AWS has actually charged, read via `ce:GetCostAndUsage` using the UnblendedCost metric. This surfaces drift between the two --- for example, the same workspace controlled from two machines can report different local estimates while AWS bills one number. Per-instance isolation uses the `prism:instance-id` cost-allocation tag when it is activated in the Billing console; when the tag is inactive, the command falls back to the region's EC2 total and warns that it may include other instances. `--billed-only` shows just the AWS figure. New daemon endpoint `GET /api/v1/instances/{name}/billed-cost`. Requires the daemon's AWS identity to hold the `ce:GetCostAndUsage` permission; access-denied errors include the fix.
 - **The persistence seam (`pkg/seam`)** — the shared record/persistence + identity interface

--- a/cmd/prism-gui/frontend/package-lock.json
+++ b/cmd/prism-gui/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism-gui",
-  "version": "0.35.5",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism-gui",
-      "version": "0.35.5",
+      "version": "0.36.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/cmd/prism-gui/frontend/package.json
+++ b/cmd/prism-gui/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-gui",
-  "version": "0.35.5",
+  "version": "0.36.0",
   "description": "Prism Professional GUI Frontend",
   "type": "module",
   "scripts": {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ import (
 var (
 	// Version is the current version of Prism.
 	// Should be in the format MAJOR.MINOR.PATCH.
-	Version = "0.35.5"
+	Version = "0.36.0"
 
 	// GitCommit is the git commit hash of the build.
 	GitCommit = ""


### PR DESCRIPTION
## Release v0.36.0

Minor release (SemVer): new backward-compatible features plus the security and dependency work accumulated since v0.35.5. No breaking changes.

### Added
- **`prism workspace cost --billed`** — AWS-billed ("billed so far") cost from Cost Explorer, shown next to prism's local estimate with the delta between them. New endpoint `GET /api/v1/instances/{name}/billed-cost`. (#624)
- **Persistence seam (`pkg/seam`)** + **DynamoDB-backed store**, wired into the daemon (opt-in via `PRISM_SEAM_BACKEND=dynamodb`; file-backed `~/.prism` by default — desktop behavior unchanged). (#635)

### Fixed
- Daemon preserves state history across AWS propagation lag; guards phantom rollback transitions and stale `DeletionTime`. (#621)

### Security
- `x/crypto` → v0.53, `x/net` → v0.55, `go-git` → v5.19.1, + npm audit fixes. `govulncheck` and Trivy (HIGH/CRITICAL) clean. (#630, #633)

### Version bumps
- `pkg/version/version.go` → 0.36.0
- `cmd/prism-gui/frontend/package.json` + `package-lock.json` → 0.36.0
- CHANGELOG.md: `[Unreleased]` promoted to `[0.36.0] - 2026-07-07`

### Release gates (all pass)
`go build ./...` · `go test ./...` · frontend unit tests (286/286) · `npm run typecheck` · `gofmt` · `go vet` · `govulncheck` (0 findings)

> After merge: tag `v0.36.0` on `main` — the `release-macos` / `release-windows` workflows build binaries and publish the GitHub release on the tag.