### PR TITLE
security: bump Go to 1.26.5 (clear GO-2026-5856, crypto/tls ECH leak)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
           cache: true
 
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
           cache: true
 
       - name: Install Xcode Command Line Tools

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
           cache: true
 
       - name: Install WiX Toolset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   web access derived from the instance's services); the stale assertions for removed RDP/desktop
   port detection were dropped.
 
+### Security
+- Bump the Go directive to **1.26.5** in both modules (and pin the CI/release workflows to 1.26.5),
+  clearing **GO-2026-5856** — an Encrypted Client Hello privacy leak in the `crypto/tls` standard
+  library reachable from the daemon's HTTPS server, the web proxy, and the API client. `govulncheck`
+  now reports zero affecting vulnerabilities under go1.26.5.
+
 ## [0.36.0] - 2026-07-07
 
 ### Added

--- a/cmd/prism-gui/go.mod
+++ b/cmd/prism-gui/go.mod
@@ -1,6 +1,6 @@
 module github.com/scttfrdmn/prism/cmd/prism-gui
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scttfrdmn/prism
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1


### PR DESCRIPTION
## Why

A newly-published Go stdlib advisory, **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`, fixed in **go1.26.5**), started failing the **Vulnerability & SAST Scan** gate on every open PR — it's in the standard library on `main`, not introduced by any change. `govulncheck` finds it reachable from:
- `pkg/daemon/server.go` (daemon HTTPS server)
- `pkg/web/proxy.go` (reverse proxy)
- `internal/cli/app.go`, `pkg/profile/security/registry_secure.go`

## What

- Bump the `go` directive `1.26` → **`1.26.5`** in both `go.mod` and `cmd/prism-gui/go.mod`.
- Pin the hardcoded `go-version` to `1.26.5` in `ci.yml` (×2), `release-macos.yml`, `release-windows.yml`. (`security.yml` already uses `go-version-file: go.mod`, so it picks up the directive.)

## Verification (under go1.26.5)

- `go build ./...` — both modules ✅
- `go test ./...` ✅
- `go vet ./...` ✅
- `govulncheck ./...` — **"affected by 0 vulnerabilities"** (was 1: GO-2026-5856) ✅

Unblocks the SAST gate on all open PRs (#639).