### PR TITLE
release: v0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.1] - 2026-07-08
+
 ### Changed
 - **Bump Wails v3 `v3.0.0-alpha.74` → `v3.0.0-alpha.102`** in `cmd/prism-gui`. No application code
   changes required; the bump also drops a large set of transitive dependencies (Wails alpha.102 no

--- a/cmd/prism-gui/frontend/package-lock.json
+++ b/cmd/prism-gui/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism-gui",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism-gui",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/cmd/prism-gui/frontend/package.json
+++ b/cmd/prism-gui/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-gui",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Prism Professional GUI Frontend",
   "type": "module",
   "scripts": {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ import (
 var (
 	// Version is the current version of Prism.
 	// Should be in the format MAJOR.MINOR.PATCH.
-	Version = "0.36.0"
+	Version = "0.36.1"
 
 	// GitCommit is the git commit hash of the build.
 	GitCommit = ""


### PR DESCRIPTION
## Release v0.36.1 (patch)

Primary driver is the **security fix**; patch level is correct because nothing since v0.36.0 adds new features.

### Security
- **Go → 1.26.5**, clearing **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`), reachable from the daemon HTTPS server, web proxy, and API client. `govulncheck` reports 0 affecting vulnerabilities. (#640)

### Changed
- Wails v3 alpha.74 → alpha.102 (dependency bump, no application code change). (#637)

### Fixed
- GUI test nil-pointer panics (`TestGetInstanceAccess` / `TestEmbeddedWebView`). (#637)

### Docs
- Budget engine architecture design record + resolved decisions. (#638, #639)

### Version bumps
`pkg/version/version.go` and GUI `package.json`/`package-lock.json` → 0.36.1; CHANGELOG `[Unreleased]` promoted to `[0.36.1] - 2026-07-08`.

### Release gates (all pass under go1.26.5)
build · `go test` · frontend unit tests (286) · typecheck · gofmt · `go vet` · govulncheck (0 affecting)

> After merge: tag `v0.36.1` on `main` — the release-macos/windows workflows build binaries and publish the GitHub release on the tag.