### PR TITLE
feat(budget): adopt budgetengine for the launch gate (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.36.1] - 2026-07-08
+### Changed
+- **Budget engine adoption, Phase 1 (#643).** The launch-time monthly-budget gate
+  (`Server.isLaunchBlockedByBudget`) now makes its projected-over-limit decision via the standalone
+  `github.com/scttfrdmn/budgetengine` library (`engine.CheckLaunch`) instead of an inline
+  comparison. A new `pkg/daemon/budget_engine.go` adapter feeds the engine a single-source,
+  read-only view of the project's existing embedded budget — **no change to budget storage, the
+  spend model, or the HTTP API.** Block/allow behavior is a verified parity of the previous
+  flat-limit check (`budget_engine_test.go`); fail-open on engine error is preserved. Depends on
+  `github.com/scttfrdmn/budgetengine v0.1.0` (a public, zero-dependency module). Later phases move
+  spend to an event ledger (#644) and retire the JSON tracker (#645).
 
 ### Changed
 - **Bump Wails v3 `v3.0.0-alpha.74` → `v3.0.0-alpha.102`** in `cmd/prism-gui`. No application code

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/scttfrdmn/budgetengine v0.1.0
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/scttfrdmn/budgetengine v0.1.0 h1:vphN+PEXT8QpEVW72ztNilYz1cL47bZLiTWY+/ApmDQ=
+github.com/scttfrdmn/budgetengine v0.1.0/go.mod h1:pNdKHOUFCnw7uD2locx5oqCWD2kb08/240H4RAkn9u0=
 github.com/scttfrdmn/substrate v0.48.0 h1:Apumf1EsTK5Sz9MLnCLZ6pQcyj/ChneCmun39AqJ0jI=
 github.com/scttfrdmn/substrate v0.48.0/go.mod h1:gKkftVt2MxQ465Rs/Na4SsEvm/SJMBypfCGmdKlvfro=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=

--- a/pkg/daemon/budget_engine.go
+++ b/pkg/daemon/budget_engine.go
@@ -1,0 +1,111 @@
+package daemon
+
+import (
+	"context"
+	"time"
+
+	be "github.com/scttfrdmn/budgetengine"
+	bepolicy "github.com/scttfrdmn/budgetengine/policy"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// This file is Phase 1 of Prism's adoption of the standalone budgetengine library
+// (github.com/scttfrdmn/budgetengine). It routes the launch-time monthly-limit budget gate through
+// engine.CheckLaunch, WITHOUT changing Prism's budget storage or spend model.
+//
+// The engine is fed a read-only, in-process view synthesized from the project's existing embedded
+// budget (types.ProjectBudget): a single funding source over the budget window, one allocation, and
+// one synthetic spend event carrying the already-cached SpentAmount. This is the degenerate
+// single-source case, which reproduces today's flat monthly-limit semantics exactly — the real
+// event-sourced spend ledger arrives in Phase 2 (#644). No new persistence is introduced here.
+
+const engineAllocationID = "project" // Phase 1 uses one implicit allocation per project
+
+// projectBudgetView adapts a project's embedded budget into the engine's read ports (SpendSource +
+// PlanSource). It is constructed per check from current data, so it needs no storage of its own.
+type projectBudgetView struct {
+	plan  []be.PlanEvent
+	spend []be.SpendEvent
+}
+
+func (v projectBudgetView) Plan(_ context.Context, _ be.Scope) ([]be.PlanEvent, error) {
+	return v.plan, nil
+}
+
+func (v projectBudgetView) Spend(_ context.Context, _ be.Scope) ([]be.SpendEvent, error) {
+	return v.spend, nil
+}
+
+// budgetWindow derives the [start,end] the engine paces over from the project's budget period.
+// Monthly (the limit case) → the current calendar month; explicit EndDate wins when present;
+// otherwise a one-month window from StartDate (or now).
+func budgetWindow(b *types.ProjectBudget, now time.Time) be.Window {
+	start := b.StartDate
+	if start.IsZero() {
+		start = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	}
+	if b.EndDate != nil && !b.EndDate.IsZero() {
+		return be.Window{Start: start, End: *b.EndDate}
+	}
+	switch b.BudgetPeriod {
+	case types.BudgetPeriodMonthly, "":
+		// Current month: first of this month → first of next month.
+		s := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		return be.Window{Start: s, End: s.AddDate(0, 1, 0)}
+	default:
+		// Project/weekly/daily fall back to a month-long window from start (Phase 1 parity only).
+		return be.Window{Start: start, End: start.AddDate(0, 1, 0)}
+	}
+}
+
+// newMonthlyLimitEngine builds an engine + view for the monthly-limit launch gate over an explicit
+// window, evaluated at evalAt. The funding "source" is the monthly limit spread over the window; a
+// single synthetic spend event carries the cached SpentAmount. Policies are the single-source parity
+// trio (ExpiryFirst × RateAdjust × DeadlineFloatPolicy): no banking, block at the ceiling — matching
+// today's projected>limit→403 behavior. warnThreshold ~1.0 disables the warn band in Phase 1 so the
+// gate's block/allow decisions are identical to the current code (Warn is introduced in a later
+// phase once spend is a real ledger).
+func newMonthlyLimitEngine(b *types.ProjectBudget, win be.Window, evalAt time.Time) (*be.Engine, projectBudgetView) {
+	limit := 0.0
+	if b.MonthlyLimit != nil {
+		limit = *b.MonthlyLimit
+	}
+
+	view := projectBudgetView{
+		plan: []be.PlanEvent{
+			{Kind: be.KindWindowExtended, Seq: 1, At: win.Start, Window: &be.Window{Start: win.Start, End: win.End}},
+			{Kind: be.KindSourceAdded, Seq: 2, At: win.Start,
+				Source: &be.FundingSource{ID: "monthly-limit", Amount: limit, Start: win.Start, End: win.End}},
+			{Kind: be.KindAllocationChanged, Seq: 3,
+				Allocation: &be.Allocation{ID: engineAllocationID, ProjectID: "", Amount: 0}}, // uncapped: draws whole source
+		},
+		// Phase 1: cached spend as one synthetic event, stamped at window start so it counts as
+		// already-incurred (available_to_date at `now` is the full paced ceiling to date).
+		spend: []be.SpendEvent{
+			{ID: "cached-spend", AllocationID: engineAllocationID, Amount: b.SpentAmount, At: win.Start, Source: "prism-cached"},
+		},
+	}
+
+	eng := be.New(view, view, be.FixedClock{T: evalAt},
+		be.WithSourcing(bepolicy.ExpiryFirst{}),
+		be.WithPacing(bepolicy.RateAdjust{}),
+		be.WithProjection(bepolicy.DeadlineFloatPolicy{}),
+		be.WithWarnThreshold(0.999), // effectively disable the warn band for Phase 1 parity
+	)
+	return eng, view
+}
+
+// checkMonthlyLimitViaEngine is the engine-backed replacement for the launch gate's
+// projected>monthly-limit check. It returns the engine Decision for a launch of estimatedCost
+// against the project's monthly budget. The caller maps Block→403 and Allow/Warn→proceed.
+//
+// For a monthly budget, the engine's paced ceiling at end-of-window equals the full monthly limit,
+// which is the quantity the old code compared against — so with a whole-window source and the cached
+// spend, Decision.Projected/EffectiveBalance mirror currentSpend+estimate vs. monthlyLimit.
+func (s *Server) checkMonthlyLimitViaEngine(b *types.ProjectBudget, estimatedCost float64) (be.Decision, error) {
+	// Evaluate at window end so available_to_date == full monthly limit (paced ceiling matches the
+	// flat limit the legacy gate used). This keeps Phase 1 a faithful parity of the old comparison.
+	win := budgetWindow(b, time.Now())
+	eng, _ := newMonthlyLimitEngine(b, win, win.End)
+	return eng.CheckLaunch(context.Background(), be.Scope{}, engineAllocationID, estimatedCost)
+}

--- a/pkg/daemon/budget_engine_test.go
+++ b/pkg/daemon/budget_engine_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+func ptr(f float64) *float64 { return &f }
+
+// TestCheckMonthlyLimitViaEngine_ParityWithFlatLimit is the guardrail for Phase 1: the engine-backed
+// monthly-limit gate must block exactly when the old projected>limit comparison did. Table drives
+// (monthlyLimit, spent, estimatedCost) → expected Allowed().
+func TestCheckMonthlyLimitViaEngine_ParityWithFlatLimit(t *testing.T) {
+	cases := []struct {
+		name          string
+		limit         float64
+		spent         float64
+		estimatedCost float64
+		wantAllowed   bool // old logic: (spent+est) > limit → blocked
+	}{
+		{"well under", 1000, 100, 50, true},
+		{"exactly at limit", 1000, 900, 100, true},    // projected == limit → not > → allowed
+		{"one cent over", 1000, 900, 100.01, false},   // projected > limit → blocked
+		{"already over", 1000, 1200, 10, false},       // over before the launch → blocked
+		{"zero spent big launch", 500, 0, 600, false}, // single launch exceeds limit → blocked
+		{"zero spent small launch", 500, 0, 100, true},
+	}
+	s := &Server{}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := &types.ProjectBudget{
+				MonthlyLimit: ptr(c.limit),
+				SpentAmount:  c.spent,
+				BudgetPeriod: types.BudgetPeriodMonthly,
+			}
+			// Old logic, the parity oracle.
+			oldBlocked := (c.spent + c.estimatedCost) > c.limit
+
+			dec, err := s.checkMonthlyLimitViaEngine(b, c.estimatedCost)
+			if err != nil {
+				t.Fatalf("engine check errored: %v", err)
+			}
+			if dec.Allowed() == oldBlocked {
+				t.Fatalf("parity broken: engine Allowed=%v but old logic blocked=%v (limit=%.2f spent=%.2f est=%.2f, projected=%.2f eff=%.2f verdict=%s)",
+					dec.Allowed(), oldBlocked, c.limit, c.spent, c.estimatedCost, dec.Projected, dec.EffectiveBalance, dec.Verdict)
+			}
+			if dec.Allowed() != c.wantAllowed {
+				t.Fatalf("Allowed=%v, want %v (verdict=%s)", dec.Allowed(), c.wantAllowed, dec.Verdict)
+			}
+		})
+	}
+}
+
+// TestBudgetWindow_Monthly confirms a monthly budget yields the current calendar month window, so
+// the paced ceiling at window end equals the full monthly limit (the parity requirement).
+func TestBudgetWindow_Monthly(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	b := &types.ProjectBudget{BudgetPeriod: types.BudgetPeriodMonthly}
+	w := budgetWindow(b, now)
+	if w.Start != time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC) {
+		t.Fatalf("Start = %v, want Jul 1", w.Start)
+	}
+	if w.End != time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC) {
+		t.Fatalf("End = %v, want Aug 1", w.End)
+	}
+}
+
+// TestCheckMonthlyLimitViaEngine_CeilingEqualsLimit confirms the engine's EffectiveBalance at the
+// check equals the monthly limit (not a pro-rated slice) — the property that makes it a parity of
+// the flat-limit comparison rather than a paced-to-date comparison.
+func TestCheckMonthlyLimitViaEngine_CeilingEqualsLimit(t *testing.T) {
+	s := &Server{}
+	b := &types.ProjectBudget{MonthlyLimit: ptr(1000), SpentAmount: 0, BudgetPeriod: types.BudgetPeriodMonthly}
+	dec, err := s.checkMonthlyLimitViaEngine(b, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dec.EffectiveBalance < 999.5 || dec.EffectiveBalance > 1000.5 {
+		t.Fatalf("EffectiveBalance = %.2f, want ~1000 (full monthly limit)", dec.EffectiveBalance)
+	}
+}

--- a/pkg/daemon/instance_handlers.go
+++ b/pkg/daemon/instance_handlers.go
@@ -1665,9 +1665,17 @@ func (s *Server) isLaunchBlockedByBudget(req *types.LaunchRequest, w http.Respon
 	currentSpend := proj.Budget.SpentAmount
 	monthlyLimit := *proj.Budget.MonthlyLimit
 
-	// Check if this launch would exceed the monthly limit
-	projectedSpend := currentSpend + estimatedMonthlyCost
-	if projectedSpend > monthlyLimit {
+	// Budget engine adoption Phase 1 (#643): the projected>limit decision is now made by the
+	// standalone budgetengine via engine.CheckLaunch, fed a single-source view of this monthly
+	// budget. Block/allow behavior is a faithful parity of the previous flat-limit comparison; the
+	// engine gains multi-source/banking semantics in later phases. Fail open on engine error.
+	decision, decErr := s.checkMonthlyLimitViaEngine(proj.Budget, estimatedMonthlyCost)
+	if decErr != nil {
+		log.Printf("Warning: budget engine check failed for project %s, allowing launch: %v", req.ProjectID, decErr)
+		return false // Fail open
+	}
+	projectedSpend := decision.Projected
+	if !decision.Allowed() {
 		// Block the launch - would exceed budget
 		errorMsg := fmt.Sprintf("⛔ Instance launch blocked: Would exceed monthly budget limit\n\n")
 		errorMsg += "Budget Analysis:\n"


### PR DESCRIPTION
Phase 1 of adopting the standalone **`github.com/scttfrdmn/budgetengine`** library (closes #643, resolves #646). Thin, storage-free first pass.

## What
The daemon's monthly-limit launch gate (`Server.isLaunchBlockedByBudget`) now makes its projected-over-limit decision via **`engine.CheckLaunch`** instead of an inline `projected > limit` comparison.

- New `pkg/daemon/budget_engine.go` — an adapter implementing the engine's read ports (`SpendSource`/`PlanSource`) over a project's *existing* embedded budget: a single funding source spanning the budget window, one allocation, one synthetic spend event carrying the cached `SpentAmount`. Policies: `ExpiryFirst × RateAdjust × DeadlineFloatPolicy` (single-source parity, no banking), warn band disabled, evaluated at window end so the paced ceiling equals the full monthly limit.
- `isLaunchBlockedByBudget` maps `Decision`: `Block` → the existing 403 (message now populated from the engine), else proceed. Fail-open on engine error preserved.

## What does NOT change
No change to `BudgetManager`/`BudgetTracker` storage, the spend model, or any HTTP handler. `budgetengine.Scope` is a plain struct conversion from `seam.Scope`.

## Dependency
Depends on **`budgetengine v0.1.0`** — a public, zero-dependency module (tagged for this PR; CI resolves it over the normal module proxy, no auth/secret needed).

## Verification
- `go build`/`vet`/`test` both modules; `govulncheck` clean; `gofmt` clean.
- **Parity** with the old flat-limit gate is the guardrail — `budget_engine_test.go` covers the boundary cases (exactly-at-limit → allowed, one-cent-over → blocked, already-over → blocked).
- **Live smoke:** a launch into a \$1/mo-limit project returns HTTP 403 with the budget-analysis message, its `Projected Total` now computed by the engine `Decision`.

## Follow-ups (tracked, not this PR)
- #644 Phase 2 — spend as an event ledger (`SpendWriter` feeder).
- #645 Phase 3 — retire the `BudgetTracker` JSON model; re-derive analytics from `BurnState`.
- #647 — reconcile the design doc's §5.4 `EffectiveBalance` formula.