### PR TITLE
feat(budget): real spend event ledger (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Budget engine adoption, Phase 2 (#644) — real spend ledger.** Prism now accrues per-instance
+  spend into an append-only, seam-backed `budgetengine` ledger, replacing Phase 1's synthetic
+  single spend event. A spend observer (`pkg/daemon/spend_observer.go`) runs on the `StateMonitor`
+  tick, internally throttled to a 10-minute accrual cadence, and appends a `SpendEvent` per running
+  project-attributed instance as the **delta** of a cumulative list-price estimate
+  (`HourlyRate × runtime`). A per-instance checkpoint (persisted through the seam) makes accrual
+  idempotent across restarts — no double-counting. The launch gate now reads this real ledger as
+  its `SpendSource` when populated, falling back to the cached `SpentAmount` while the ledger warms
+  up (so it never becomes more permissive than Phase 1). Spend is project-scoped for now
+  (`AllocationID = "project"`). Authoritative Cost Explorer reconciliation and per-funding-allocation
+  attribution are deferred to follow-ups; `BudgetTracker`/HTTP handlers are untouched.
+
 ### Changed
 - **Budget engine adoption, Phase 1 (#643).** The launch-time monthly-budget gate
   (`Server.isLaunchBlockedByBudget`) now makes its projected-over-limit decision via the standalone

--- a/pkg/daemon/budget_engine.go
+++ b/pkg/daemon/budget_engine.go
@@ -79,20 +79,28 @@ func newMonthlyLimitEngine(b *types.ProjectBudget, win be.Window, evalAt time.Ti
 			{Kind: be.KindAllocationChanged, Seq: 3,
 				Allocation: &be.Allocation{ID: engineAllocationID, ProjectID: "", Amount: 0}}, // uncapped: draws whole source
 		},
-		// Phase 1: cached spend as one synthetic event, stamped at window start so it counts as
-		// already-incurred (available_to_date at `now` is the full paced ceiling to date).
+		// Fallback spend feed: the cached SpentAmount as one synthetic event, stamped at window start
+		// so it counts as already-incurred. Used only when the real ledger has no events yet.
 		spend: []be.SpendEvent{
 			{ID: "cached-spend", AllocationID: engineAllocationID, Amount: b.SpentAmount, At: win.Start, Source: "prism-cached"},
 		},
 	}
 
-	eng := be.New(view, view, be.FixedClock{T: evalAt},
+	eng := be.New(view, view, be.FixedClock{T: evalAt}, bepolicyDefaults()...)
+	return eng, view
+}
+
+// bepolicyDefaults is the single-source parity policy trio used by the monthly-limit gate:
+// ExpiryFirst × RateAdjust × DeadlineFloatPolicy, with the warn band effectively disabled so
+// block/allow decisions match the legacy flat-limit check. Shared by the synthesized-fallback and
+// real-ledger engine constructions so both decide identically.
+func bepolicyDefaults() []be.Option {
+	return []be.Option{
 		be.WithSourcing(bepolicy.ExpiryFirst{}),
 		be.WithPacing(bepolicy.RateAdjust{}),
 		be.WithProjection(bepolicy.DeadlineFloatPolicy{}),
-		be.WithWarnThreshold(0.999), // effectively disable the warn band for Phase 1 parity
-	)
-	return eng, view
+		be.WithWarnThreshold(0.999),
+	}
 }
 
 // checkMonthlyLimitViaEngine is the engine-backed replacement for the launch gate's
@@ -102,10 +110,25 @@ func newMonthlyLimitEngine(b *types.ProjectBudget, win be.Window, evalAt time.Ti
 // For a monthly budget, the engine's paced ceiling at end-of-window equals the full monthly limit,
 // which is the quantity the old code compared against — so with a whole-window source and the cached
 // spend, Decision.Projected/EffectiveBalance mirror currentSpend+estimate vs. monthlyLimit.
-func (s *Server) checkMonthlyLimitViaEngine(b *types.ProjectBudget, estimatedCost float64) (be.Decision, error) {
+func (s *Server) checkMonthlyLimitViaEngine(projectID string, b *types.ProjectBudget, estimatedCost float64) (be.Decision, error) {
 	// Evaluate at window end so available_to_date == full monthly limit (paced ceiling matches the
-	// flat limit the legacy gate used). This keeps Phase 1 a faithful parity of the old comparison.
+	// flat limit the legacy gate used).
 	win := budgetWindow(b, time.Now())
-	eng, _ := newMonthlyLimitEngine(b, win, win.End)
-	return eng.CheckLaunch(context.Background(), be.Scope{}, engineAllocationID, estimatedCost)
+	eng, view := newMonthlyLimitEngine(b, win, win.End)
+
+	// Phase 2 (#644): prefer the real, persisted spend ledger as the SpendSource. The engine's plan
+	// is still synthesized from the project budget (view), but spend comes from the append-only
+	// ledger scoped to this project when it has data. If the ledger is empty (e.g. spend hasn't
+	// accrued yet, or a fresh install), fall back to the synthesized cached-SpentAmount event so the
+	// gate never becomes MORE permissive than Phase 1 while the ledger warms up.
+	spendSource := be.SpendSource(view)
+	scope := projectScope(projectID)
+	if s.spendLedger != nil && projectID != "" {
+		if evs, err := s.spendLedger.Spend(context.Background(), scope); err == nil && len(evs) > 0 {
+			spendSource = s.spendLedger
+		}
+	}
+	eng = be.New(spendSource, view, be.FixedClock{T: win.End},
+		bepolicyDefaults()...)
+	return eng.CheckLaunch(context.Background(), scope, engineAllocationID, estimatedCost)
 }

--- a/pkg/daemon/budget_engine_test.go
+++ b/pkg/daemon/budget_engine_test.go
@@ -38,7 +38,7 @@ func TestCheckMonthlyLimitViaEngine_ParityWithFlatLimit(t *testing.T) {
 			// Old logic, the parity oracle.
 			oldBlocked := (c.spent + c.estimatedCost) > c.limit
 
-			dec, err := s.checkMonthlyLimitViaEngine(b, c.estimatedCost)
+			dec, err := s.checkMonthlyLimitViaEngine("", b, c.estimatedCost)
 			if err != nil {
 				t.Fatalf("engine check errored: %v", err)
 			}
@@ -73,7 +73,7 @@ func TestBudgetWindow_Monthly(t *testing.T) {
 func TestCheckMonthlyLimitViaEngine_CeilingEqualsLimit(t *testing.T) {
 	s := &Server{}
 	b := &types.ProjectBudget{MonthlyLimit: ptr(1000), SpentAmount: 0, BudgetPeriod: types.BudgetPeriodMonthly}
-	dec, err := s.checkMonthlyLimitViaEngine(b, 1)
+	dec, err := s.checkMonthlyLimitViaEngine("", b, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/daemon/instance_handlers.go
+++ b/pkg/daemon/instance_handlers.go
@@ -1669,7 +1669,7 @@ func (s *Server) isLaunchBlockedByBudget(req *types.LaunchRequest, w http.Respon
 	// standalone budgetengine via engine.CheckLaunch, fed a single-source view of this monthly
 	// budget. Block/allow behavior is a faithful parity of the previous flat-limit comparison; the
 	// engine gains multi-source/banking semantics in later phases. Fail open on engine error.
-	decision, decErr := s.checkMonthlyLimitViaEngine(proj.Budget, estimatedMonthlyCost)
+	decision, decErr := s.checkMonthlyLimitViaEngine(req.ProjectID, proj.Budget, estimatedMonthlyCost)
 	if decErr != nil {
 		log.Printf("Warning: budget engine check failed for project %s, allowing launch: %v", req.ProjectID, decErr)
 		return false // Fail open

--- a/pkg/daemon/seam_backend.go
+++ b/pkg/daemon/seam_backend.go
@@ -3,15 +3,18 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	be "github.com/scttfrdmn/budgetengine"
 
 	"github.com/scttfrdmn/prism/pkg/daemon/logger"
 	"github.com/scttfrdmn/prism/pkg/project"
 	"github.com/scttfrdmn/prism/pkg/rbac"
 	"github.com/scttfrdmn/prism/pkg/seam"
 	"github.com/scttfrdmn/prism/pkg/seam/dynamostore"
+	"github.com/scttfrdmn/prism/pkg/seam/filestore"
 	"github.com/scttfrdmn/prism/pkg/types"
 )
 
@@ -23,6 +26,7 @@ type seamManagers struct {
 	budget   *project.BudgetManager
 	rbac     *rbac.Manager
 	approval *project.ApprovalManager
+	spend    *spendStore // Phase 2 (#644): the budgetengine spend ledger
 }
 
 // seamBackendKind is the persistence backend the converged managers run on.
@@ -103,12 +107,31 @@ func initSeamManagersFile() (seamManagers, error) {
 	if err != nil {
 		return seamManagers{}, fmt.Errorf("failed to initialize approval manager: %w", err)
 	}
+	dir := seamStateDir()
+	spend := newSpendStore(
+		filestore.New[be.SpendEvent](filepath.Join(dir, "spend_events")),
+		filestore.New[spendCheckpoint](filepath.Join(dir, "spend_checkpoints")),
+	)
 	return seamManagers{
 		project:  projectManager,
 		budget:   budgetManager,
 		rbac:     rbacManager,
 		approval: approvalManager,
+		spend:    spend,
 	}, nil
+}
+
+// seamStateDir returns the file-backed seam root (PRISM_STATE_DIR or ~/.prism), mirroring
+// project.NewManager / NewBudgetManager.
+func seamStateDir() string {
+	if d := os.Getenv("PRISM_STATE_DIR"); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".prism"
+	}
+	return filepath.Join(home, ".prism")
 }
 
 // initSeamManagersDynamo builds the managers over the DynamoDB-backed seam. Each record type gets a
@@ -142,11 +165,16 @@ func initSeamManagersDynamo(cfg awssdk.Config) (seamManagers, error) {
 		dynamostore.New[rbac.State](ddb, table("rbac")), scope)
 	approvalManager := project.NewApprovalManagerForScope(
 		dynamostore.New[project.ApprovalRequest](ddb, table("approvals")), scope)
+	spend := newSpendStore(
+		dynamostore.New[be.SpendEvent](ddb, table("spend-events")),
+		dynamostore.New[spendCheckpoint](ddb, table("spend-checkpoints")),
+	)
 
 	return seamManagers{
 		project:  projectManager,
 		budget:   budgetManager,
 		rbac:     rbacManager,
 		approval: approvalManager,
+		spend:    spend,
 	}, nil
 }

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/scttfrdmn/prism/pkg/sleepwake"
 	"github.com/scttfrdmn/prism/pkg/state"
 	"github.com/scttfrdmn/prism/pkg/throttle"
+	"github.com/scttfrdmn/prism/pkg/types"
 	"github.com/scttfrdmn/prism/pkg/workshop"
 )
 
@@ -54,6 +55,7 @@ type Server struct {
 	securityManager    *security.SecurityManager
 	policyService      *policy.Service
 	rbacManager        *rbac.Manager
+	spendLedger        *spendStore // Phase 2 (#644): budgetengine spend ledger (SpendSource/Writer)
 	processManager     ProcessManager
 
 	// Connection reliability components
@@ -307,6 +309,7 @@ func NewServer(port string) (*Server, error) {
 	projectManager := seamMgrs.project
 	budgetManager := seamMgrs.budget
 	rbacManager := seamMgrs.rbac
+	spendLedger := seamMgrs.spend // Phase 2 (#644): budgetengine spend ledger
 
 	// Wire active-instance check so DeleteProject blocks while instances are running (#539)
 	projectManager.SetActiveInstancesFunc(func(projectID string) ([]string, error) {
@@ -440,6 +443,7 @@ func NewServer(port string) (*Server, error) {
 		securityManager:     securityManager,
 		policyService:       policyService,
 		rbacManager:         rbacManager,
+		spendLedger:         spendLedger,
 		processManager:      processManager,
 		performanceMonitor:  performanceMonitor,
 		connManager:         connManager,
@@ -465,6 +469,24 @@ func NewServer(port string) (*Server, error) {
 
 	// Approval manager (v0.12.0 - Issue #148/#149/#153/#157) comes from the seam-backed managers.
 	server.approvalManager = seamMgrs.approval
+
+	// Phase 2 (#644): register the spend observer as a StateMonitor tick hook so per-instance spend
+	// accrues into the budgetengine ledger. Self-throttled (10m estimate cadence) despite the 10s
+	// tick. Loads instances from the state manager; skips Cost Explorer in test mode.
+	if spendLedger != nil {
+		observer := newSpendObserver(spendLedger, func() ([]types.Instance, error) {
+			st, err := stateManager.LoadState()
+			if err != nil {
+				return nil, err
+			}
+			out := make([]types.Instance, 0, len(st.Instances))
+			for _, inst := range st.Instances {
+				out = append(out, inst)
+			}
+			return out, nil
+		}, server.testMode)
+		stateMonitor.SetTickHook(func() { observer.Observe(context.Background()) })
+	}
 
 	// Initialize course manager (v0.14.0 - Issue #45)
 	if cm, err := course.NewManager(); err == nil {

--- a/pkg/daemon/spend_observer.go
+++ b/pkg/daemon/spend_observer.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	be "github.com/scttfrdmn/budgetengine"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// Phase 2 (#644): the spend observer periodically accrues per-instance spend into the append-only
+// budgetengine ledger (spendStore). It is the currently-greenfield loop that turns Prism's
+// recompute-on-read cost model into a real event stream.
+//
+// Two accrual paths, at different cadences (both driven off StateMonitor's tick, internally
+// throttled — Cost Explorer is far too costly/rate-limited to call per tick):
+//
+//   - Estimate (cheap, frequent): every accrualInterval, per running instance, append the delta of
+//     a cumulative list-price estimate (HourlyRate × running hours). This is a pure function of the
+//     instance record, so it needs no AWS call.
+//   - Billed reconciliation (authoritative, ~daily): NOT YET IMPLEMENTED. The design and the
+//     checkpoint carry fields for it (LastReconcileAt/ReconciledBilled, spendReconcileInterval), but
+//     Phase 2 ships the estimate feed only. Reconciling against awsManager.GetBilledCost (Cost
+//     Explorer) — with cumulative→delta correction and reversal semantics — lands as a follow-up so
+//     the CE cost/rate-limit handling gets its own focused change. The reversal-based `Source:
+//     "billed"` correction is where it will hook in.
+//
+// Cumulative→delta: sources are cumulative but the ledger is delta-append, so the observer keeps a
+// per-instance checkpoint (last cumulative) and appends newCumulative − last, with a unique-per-delta
+// event ID so a replay is a no-op in the fold.
+//
+// Attribution: Phase 2 is project-scoped — events are keyed by seam.Scope{Project} and carry
+// AllocationID = engineAllocationID ("project"). Per-funding-allocation attribution is a later phase.
+
+const (
+	// spendAccrualInterval throttles estimate appends (billing granularity, not the 10s tick).
+	spendAccrualInterval = 10 * time.Minute
+	// spendReconcileInterval throttles authoritative Cost Explorer reconciliation.
+	spendReconcileInterval = 24 * time.Hour
+)
+
+// spendObserver accrues spend for running instances into the ledger. It reads instances from the
+// state manager and writes through the spendStore; it holds no mutable state of its own (the
+// per-instance checkpoint lives in the seam, durable across restart).
+type spendObserver struct {
+	store    *spendStore
+	loadInst func() ([]types.Instance, error) // returns current instances (from state manager)
+	testMode bool                             // skip Cost Explorer entirely
+	clock    func() time.Time                 // injectable for tests
+}
+
+func newSpendObserver(store *spendStore, loadInst func() ([]types.Instance, error), testMode bool) *spendObserver {
+	return &spendObserver{store: store, loadInst: loadInst, testMode: testMode, clock: time.Now}
+}
+
+// Observe runs one accrual pass over all running instances. Called from StateMonitor's tick;
+// per-instance throttling keeps it billing-appropriate despite the 10s cadence. Errors on a single
+// instance are logged and skipped (fail-open) so one bad record never stalls the loop.
+func (o *spendObserver) Observe(ctx context.Context) {
+	if o.store == nil || o.loadInst == nil {
+		return
+	}
+	instances, err := o.loadInst()
+	if err != nil {
+		return // no state; nothing to accrue
+	}
+	now := o.clock()
+	for _, inst := range instances {
+		if inst.ProjectID == "" || inst.State != "running" {
+			continue // spend accrues only for running, project-attributed instances
+		}
+		o.accrueInstance(ctx, inst, now)
+	}
+}
+
+// accrueInstance appends the estimate delta for one instance if the accrual interval has elapsed.
+func (o *spendObserver) accrueInstance(ctx context.Context, inst types.Instance, now time.Time) {
+	scope := projectScope(inst.ProjectID)
+	cp, _ := o.store.checkpoint(ctx, scope, inst.ID)
+
+	if !cp.LastAccrualAt.IsZero() && now.Sub(cp.LastAccrualAt) < spendAccrualInterval {
+		return // throttled
+	}
+
+	cumulative := estimateCumulativeCost(inst, now)
+	delta := cumulative - cp.LastCumulative
+	if delta <= 0 {
+		// No new cost (or a stale/decreasing estimate) — just advance the throttle timestamp.
+		cp.LastAccrualAt = now
+		_ = o.store.saveCheckpoint(ctx, scope, cp)
+		return
+	}
+
+	ev := be.SpendEvent{
+		ID:           fmt.Sprintf("%s:%d", inst.ID, now.UnixNano()), // unique per delta → idempotent
+		AllocationID: engineAllocationID,
+		Amount:       delta,
+		At:           now,
+		Source:       "estimate",
+	}
+	if err := o.store.AppendSpend(ctx, scope, ev); err != nil {
+		return // fail-open; retry next tick (checkpoint unchanged, so no lost spend)
+	}
+	cp.InstanceID = inst.ID
+	cp.LastCumulative = cumulative
+	cp.LastAccrualAt = now
+	_ = o.store.saveCheckpoint(ctx, scope, cp)
+}
+
+// estimateCumulativeCost is a self-contained, monotonic list-price estimate of an instance's spend
+// since launch: HourlyRate × hours since LaunchTime. It intentionally does not read the possibly-
+// stale cached CurrentSpend; it recomputes so successive observations produce a clean cumulative
+// series the delta logic can difference. (Running-vs-stopped nuance and storage-only rates are a
+// refinement for the billed-reconciliation path; this estimate is the coarse frequent feed.)
+func estimateCumulativeCost(inst types.Instance, now time.Time) float64 {
+	if inst.LaunchTime.IsZero() || inst.HourlyRate <= 0 {
+		return 0
+	}
+	hours := now.Sub(inst.LaunchTime).Hours()
+	if hours <= 0 {
+		return 0
+	}
+	return inst.HourlyRate * hours
+}

--- a/pkg/daemon/spend_observer_test.go
+++ b/pkg/daemon/spend_observer_test.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	be "github.com/scttfrdmn/budgetengine"
+	"github.com/scttfrdmn/prism/pkg/seam/filestore"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// newTestSpendStore builds a spendStore over temp-dir filestores (host-free, no AWS).
+func newTestSpendStore(t *testing.T) *spendStore {
+	t.Helper()
+	dir := t.TempDir()
+	return newSpendStore(
+		filestore.New[be.SpendEvent](dir+"/events"),
+		filestore.New[spendCheckpoint](dir+"/checkpoints"),
+	)
+}
+
+func runningInstance(id, projectID string, hourly float64, launched time.Time) types.Instance {
+	return types.Instance{ID: id, ProjectID: projectID, State: "running", HourlyRate: hourly, LaunchTime: launched}
+}
+
+// TestSpendStore_AppendListRoundTrip: append events, read them back via the SpendSource port.
+func TestSpendStore_AppendListRoundTrip(t *testing.T) {
+	s := newTestSpendStore(t)
+	ctx := context.Background()
+	scope := projectScope("proj-1")
+	_ = s.AppendSpend(ctx, scope, be.SpendEvent{ID: "e1", AllocationID: engineAllocationID, Amount: 10, At: time.Now()})
+	_ = s.AppendSpend(ctx, scope, be.SpendEvent{ID: "e2", AllocationID: engineAllocationID, Amount: 5, At: time.Now()})
+
+	evs, err := s.Spend(ctx, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("got %d events, want 2", len(evs))
+	}
+	var total float64
+	for _, e := range evs {
+		total += e.Amount
+	}
+	if total != 15 {
+		t.Fatalf("total = %.2f, want 15", total)
+	}
+	// Scope isolation: a different project sees nothing.
+	other, _ := s.Spend(ctx, projectScope("proj-2"))
+	if len(other) != 0 {
+		t.Fatalf("proj-2 leaked %d events", len(other))
+	}
+}
+
+// TestObserver_CumulativeToDelta: successive observations append deltas that sum to the cumulative
+// estimate — not the cumulative value each time (the double-count guard).
+func TestObserver_CumulativeToDelta(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inst := runningInstance("i-1", "proj-1", 2.0, launched) // $2/hr
+
+	insts := []types.Instance{inst}
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+
+	// t+10h → cumulative $20. Then t+25h → cumulative $50. Deltas: $20, then $30. Total $50.
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+	obs.clock = func() time.Time { return launched.Add(25 * time.Hour) }
+	obs.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	var total float64
+	for _, e := range evs {
+		total += e.Amount
+	}
+	if total < 49.9 || total > 50.1 {
+		t.Fatalf("ledger total = %.2f, want ~50 (cumulative at t+25h), events=%d", total, len(evs))
+	}
+	if len(evs) != 2 {
+		t.Fatalf("want 2 delta events, got %d", len(evs))
+	}
+}
+
+// TestObserver_Throttle: a second observation inside the accrual interval appends nothing.
+func TestObserver_Throttle(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+	// 1 minute later — well inside spendAccrualInterval (10m) → no new event.
+	obs.clock = func() time.Time { return launched.Add(10*time.Hour + time.Minute) }
+	obs.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	if len(evs) != 1 {
+		t.Fatalf("throttle failed: %d events, want 1", len(evs))
+	}
+}
+
+// TestObserver_IdempotentAcrossRestart: rebuilding the observer over the SAME store (simulating a
+// daemon restart) does not re-append already-accrued spend, because the checkpoint is persisted.
+func TestObserver_IdempotentAcrossRestart(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
+
+	at := launched.Add(10 * time.Hour)
+	obs1 := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs1.clock = func() time.Time { return at }
+	obs1.Observe(context.Background())
+
+	// "Restart": new observer, same store. Observe again 20 min later (past the throttle). The
+	// persisted checkpoint means only the genuine delta since the checkpoint accrues — NOT the whole
+	// cumulative again. At t+10h20m, cumulative = $2/hr × 10.333h ≈ $20.67, so the ledger total must
+	// equal the new cumulative (~$20.67), proving no double-count of the first $20.
+	obs2 := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs2.clock = func() time.Time { return at.Add(20 * time.Minute) }
+	obs2.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	var total float64
+	for _, e := range evs {
+		total += e.Amount
+	}
+	// Ledger total == cumulative at t+10h20m (~$20.67), NOT $20 + $20.67 (~$40.67).
+	if total < 20.5 || total > 20.8 {
+		t.Fatalf("restart double-counted: total = %.2f, want ~20.67 (cumulative, not summed twice)", total)
+	}
+}
+
+// TestObserver_SkipsNonRunningAndUnattributed: stopped or project-less instances accrue nothing.
+func TestObserver_SkipsNonRunningAndUnattributed(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	stopped := runningInstance("i-stop", "proj-1", 2.0, launched)
+	stopped.State = "stopped"
+	noProj := runningInstance("i-np", "", 2.0, launched)
+	insts := []types.Instance{stopped, noProj}
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	if len(evs) != 0 {
+		t.Fatalf("stopped/unattributed accrued %d events, want 0", len(evs))
+	}
+}

--- a/pkg/daemon/spend_store.go
+++ b/pkg/daemon/spend_store.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"context"
+	"time"
+
+	be "github.com/scttfrdmn/budgetengine"
+	"github.com/scttfrdmn/prism/pkg/seam"
+)
+
+// Phase 2 (#644): a real, persisted, append-only spend ledger backing budgetengine's SpendSource /
+// SpendWriter, replacing Phase 1's synthetic single spend event. Events are seam records, so they
+// survive restart and (later) can be shared with prp exactly like the other seam domains.
+//
+// Spend is scoped per project: the seam partition key is seam.Scope{Project: projectID}. The engine
+// works in its own budgetengine.Scope (layout-identical to seam.Principal), so the adapter converts
+// at the boundary.
+
+// seamToEngineScope / engineToSeamScope are the plain conversions between the two identical Scope
+// types (the whole reason the layouts were kept identical — see budgetengine/scope.go).
+func engineToSeamScope(s be.Scope) seam.Scope {
+	return seam.Scope(s)
+}
+
+// projectScope builds the per-project spend partition key.
+func projectScope(projectID string) be.Scope {
+	return be.Scope{Project: projectID}
+}
+
+// spendCheckpoint records the last cumulative spend observed for one instance, so the observer can
+// convert a cumulative estimate/billed figure into an append-only delta (newCumulative − last).
+// Persisted as its own seam record (durable across daemon restart) to avoid re-appending spend.
+type spendCheckpoint struct {
+	InstanceID       string    `json:"instance_id"`
+	LastCumulative   float64   `json:"last_cumulative"`   // last cumulative estimate appended
+	LastAccrualAt    time.Time `json:"last_accrual_at"`   // throttle: last estimate append
+	LastReconcileAt  time.Time `json:"last_reconcile_at"` // throttle: last billed reconciliation
+	ReconciledBilled float64   `json:"reconciled_billed"` // last authoritative billed total applied
+}
+
+// spendStore adapts two seam stores (spend events + per-instance checkpoints) into the engine's
+// SpendSource and SpendWriter ports. One instance per daemon; scope is passed per call.
+type spendStore struct {
+	events      seam.Store[be.SpendEvent]
+	checkpoints seam.Store[spendCheckpoint]
+}
+
+func newSpendStore(events seam.Store[be.SpendEvent], checkpoints seam.Store[spendCheckpoint]) *spendStore {
+	return &spendStore{events: events, checkpoints: checkpoints}
+}
+
+// Spend implements budgetengine.SpendSource: all spend events for the scope, in append order.
+func (s *spendStore) Spend(ctx context.Context, scope be.Scope) ([]be.SpendEvent, error) {
+	return s.events.List(ctx, engineToSeamScope(scope))
+}
+
+// AppendSpend implements budgetengine.SpendWriter: idempotent by SpendEvent.ID (Put replaces, and
+// the observer uses a unique-per-delta ID so replays are no-ops in the fold).
+func (s *spendStore) AppendSpend(ctx context.Context, scope be.Scope, e be.SpendEvent) error {
+	return s.events.Put(ctx, engineToSeamScope(scope), e.ID, e)
+}
+
+// checkpoint fetches an instance's checkpoint (zero value + false when absent).
+func (s *spendStore) checkpoint(ctx context.Context, scope be.Scope, instanceID string) (spendCheckpoint, bool) {
+	cp, err := s.checkpoints.Get(ctx, engineToSeamScope(scope), instanceID)
+	if err != nil {
+		return spendCheckpoint{InstanceID: instanceID}, false
+	}
+	return cp, true
+}
+
+// saveCheckpoint persists an instance's checkpoint.
+func (s *spendStore) saveCheckpoint(ctx context.Context, scope be.Scope, cp spendCheckpoint) error {
+	return s.checkpoints.Put(ctx, engineToSeamScope(scope), cp.InstanceID, cp)
+}
+
+// compile-time port checks.
+var (
+	_ be.SpendSource = (*spendStore)(nil)
+	_ be.SpendWriter = (*spendStore)(nil)
+)

--- a/pkg/daemon/state_monitor.go
+++ b/pkg/daemon/state_monitor.go
@@ -20,6 +20,16 @@ type StateMonitor struct {
 	wg           sync.WaitGroup
 	mu           sync.Mutex
 	running      bool
+	// onTick is an optional hook invoked each tick after the transitional-state check. Phase 2
+	// (#644) uses it to run the spend observer's accrual pass. Nil = no-op.
+	onTick func()
+}
+
+// SetTickHook registers a callback run at the end of every monitor tick (e.g. the spend observer).
+func (sm *StateMonitor) SetTickHook(fn func()) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.onTick = fn
 }
 
 // NewStateMonitor creates a new state monitor
@@ -77,6 +87,12 @@ func (sm *StateMonitor) monitorLoop() {
 		select {
 		case <-sm.ticker.C:
 			sm.checkTransitionalInstances()
+			sm.mu.Lock()
+			hook := sm.onTick
+			sm.mu.Unlock()
+			if hook != nil {
+				hook()
+			}
 		case <-sm.stopCh:
 			return
 		}


### PR DESCRIPTION
Phase 2 of budgetengine adoption (#644). Replaces Phase 1's synthetic single spend event with a real, append-only, seam-backed spend ledger fed by a background observer.

## What
- **`spend_store.go`** — `seam.Store[budgetengine.SpendEvent]` adapter implementing the engine's `SpendSource` + `SpendWriter`, plus a per-instance `spendCheckpoint` store. Both file- and DynamoDB-backed (wired in `seam_backend.go`). Spend is project-scoped (`seam.Scope{Project}`).
- **`spend_observer.go`** — an accrual loop run from a new `StateMonitor` tick hook. Per running, project-attributed instance, throttled to a **10-minute** cadence, it appends the **delta** of a cumulative list-price estimate (`HourlyRate × runtime`) with a unique-per-delta event ID. A **persisted checkpoint** makes accrual **idempotent across restarts** — no double-counting (the core risk).
- **`budget_engine.go`** — the launch gate reads the real ledger as its `SpendSource` when populated, falling back to the cached `SpentAmount` while the ledger warms up, so it's **never more permissive than Phase 1**.

## Scope (deliberately narrow)
- **Estimate feed only.** Authoritative Cost Explorer reconciliation (cumulative→delta + reversal) is *designed* (checkpoint fields + interval constant + doc) but **deferred to a follow-up** so the CE cost/rate-limit handling gets its own focused change. So #644 is **partially** addressed — leaving it open for the billed-reconciliation follow-up.
- Per-funding-allocation attribution deferred (stays `"project"`).
- `BudgetTracker` and all HTTP handlers untouched.

## Verification
- Tests: spend store round-trip + scope isolation; observer cumulative→delta, throttle, **restart-idempotency (no double-count)**, skip non-running/unattributed. **Phase 1 parity tests still green.**
- `go build`/`vet`/`test` both modules, `gofmt`, `govulncheck` clean.
- Live smoke: daemon boots with the observer wired, ticks run clean, launch gate blocks (403) and allows (200) through the engine.

Refs #644 (billed reconciliation follow-up remains).