### PR TITLE
feat(budget): opt-in Cost Explorer billed reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Opt-in Cost Explorer billed-cost reconciliation (#644).** The budget spend ledger can now
+  reconcile its list-price estimates against authoritative AWS Cost Explorer billed cost, so a
+  project's recorded spend converges on real dollars (e.g. reflecting RIs/Savings Plans/spot). It is
+  **off by default** — CE calls cost money (~$0.01/call, 1–2 per instance), are rate-limited, and lag
+  ~a day — and enabled via `daemon_config.json` (`cost_reconciliation_enabled`) or
+  `PRISM_COST_RECONCILIATION=true`. The frequency is configurable
+  (`cost_reconciliation_interval_minutes`, default 1440 = daily; or `PRISM_COST_RECONCILIATION_INTERVAL`
+  as a Go duration) and clamped to a **1-hour floor**. When the per-instance `prism:instance-id`
+  cost-allocation tag isn't active in AWS Billing, reconciliation is skipped (the region-total blob
+  isn't per-instance) and the estimate is kept, with a warning to activate the tag. Reconciliation is
+  additionally skipped in test/reduced mode; the reversal+billed correction is idempotent.
 - **Budget engine adoption, Phase 2 (#644) — real spend ledger.** Prism now accrues per-instance
   spend into an append-only, seam-backed `budgetengine` ledger, replacing Phase 1's synthetic
   single spend event. A spend observer (`pkg/daemon/spend_observer.go`) runs on the `StateMonitor`

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -18,14 +18,23 @@ type Config struct {
 
 	// Monitoring settings (future expansion)
 	MonitoringIntervalSeconds int `json:"monitoring_interval_seconds,omitempty"` // Future: monitoring frequency
+
+	// Cost Explorer reconciliation (#644). The budget spend ledger always accrues cheap list-price
+	// estimates; when enabled, the observer periodically reconciles against authoritative AWS Cost
+	// Explorer billed cost. OFF by default because CE calls cost money (~$0.01/call, 1-2 per
+	// instance), are rate-limited, and lag ~a day.
+	CostReconciliationEnabled         bool `json:"cost_reconciliation_enabled"`          // opt-in; default false
+	CostReconciliationIntervalMinutes int  `json:"cost_reconciliation_interval_minutes"` // default 1440 (24h); floored at 60
 }
 
 // DefaultConfig returns the default daemon configuration
 func DefaultConfig() *Config {
 	return &Config{
-		InstanceRetentionMinutes:  5,      // Default: 5 minutes retention
-		Port:                      "8947", // Default port
-		MonitoringIntervalSeconds: 60,     // Future: default monitoring interval
+		InstanceRetentionMinutes:          5,      // Default: 5 minutes retention
+		Port:                              "8947", // Default port
+		MonitoringIntervalSeconds:         60,     // Future: default monitoring interval
+		CostReconciliationEnabled:         false,  // Opt-in: CE reconciliation off by default
+		CostReconciliationIntervalMinutes: 1440,   // Default: daily
 	}
 }
 
@@ -33,9 +42,11 @@ func DefaultConfig() *Config {
 func LoadConfig() (*Config, error) {
 	configPath := GetConfigPath()
 
-	// If config file doesn't exist, return default config
+	// If config file doesn't exist, return default config (still honoring env overrides).
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return DefaultConfig(), nil
+		config := DefaultConfig()
+		applyCostReconciliationEnv(config)
+		return config, nil
 	}
 
 	// Read config file
@@ -50,7 +61,25 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to parse daemon config: %w", err)
 	}
 
+	applyCostReconciliationEnv(config)
 	return config, nil
+}
+
+// applyCostReconciliationEnv lets env vars override the file/default for the cost-reconciliation
+// settings (env wins over file wins over default). PRISM_COST_RECONCILIATION is a bool
+// ("true"/"false"); PRISM_COST_RECONCILIATION_INTERVAL is a Go duration string (e.g. "6h", "90m").
+func applyCostReconciliationEnv(config *Config) {
+	switch os.Getenv("PRISM_COST_RECONCILIATION") {
+	case "true", "1":
+		config.CostReconciliationEnabled = true
+	case "false", "0":
+		config.CostReconciliationEnabled = false
+	}
+	if v := os.Getenv("PRISM_COST_RECONCILIATION_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			config.CostReconciliationIntervalMinutes = int(d.Minutes())
+		}
+	}
 }
 
 // SaveConfig saves daemon configuration to the standard location
@@ -85,6 +114,17 @@ func (c *Config) GetRetentionDuration() time.Duration {
 		return time.Hour * 24 * 365 * 10 // 10 years - effectively indefinite
 	}
 	return time.Duration(c.InstanceRetentionMinutes) * time.Minute
+}
+
+// GetCostReconciliationInterval returns the reconciliation interval, clamped to a 1-hour floor so a
+// misconfigured tiny value can't trigger runaway Cost Explorer spend (CE lags ~a day regardless).
+func (c *Config) GetCostReconciliationInterval() time.Duration {
+	const floor = time.Hour
+	d := time.Duration(c.CostReconciliationIntervalMinutes) * time.Minute
+	if d < floor {
+		return floor
+	}
+	return d
 }
 
 // getConfigPath returns the standard daemon configuration file path

--- a/pkg/daemon/config_test.go
+++ b/pkg/daemon/config_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig_CostReconciliationOffByDefault(t *testing.T) {
+	c := DefaultConfig()
+	if c.CostReconciliationEnabled {
+		t.Fatal("cost reconciliation must default to OFF (opt-in)")
+	}
+	if c.GetCostReconciliationInterval() != 24*time.Hour {
+		t.Fatalf("default interval = %v, want 24h", c.GetCostReconciliationInterval())
+	}
+}
+
+func TestGetCostReconciliationInterval_Floor(t *testing.T) {
+	c := &Config{CostReconciliationIntervalMinutes: 5} // below the 1h floor
+	if got := c.GetCostReconciliationInterval(); got != time.Hour {
+		t.Fatalf("interval = %v, want 1h floor (misconfig guard)", got)
+	}
+	c2 := &Config{CostReconciliationIntervalMinutes: 360} // 6h, above floor
+	if got := c2.GetCostReconciliationInterval(); got != 6*time.Hour {
+		t.Fatalf("interval = %v, want 6h", got)
+	}
+}
+
+func TestEnvOverride_CostReconciliation(t *testing.T) {
+	c := DefaultConfig()
+	t.Setenv("PRISM_COST_RECONCILIATION", "true")
+	t.Setenv("PRISM_COST_RECONCILIATION_INTERVAL", "6h")
+	applyCostReconciliationEnv(c)
+	if !c.CostReconciliationEnabled {
+		t.Fatal("env PRISM_COST_RECONCILIATION=true should enable")
+	}
+	if c.GetCostReconciliationInterval() != 6*time.Hour {
+		t.Fatalf("env interval override = %v, want 6h", c.GetCostReconciliationInterval())
+	}
+	// env can also force-disable.
+	t.Setenv("PRISM_COST_RECONCILIATION", "false")
+	applyCostReconciliationEnv(c)
+	if c.CostReconciliationEnabled {
+		t.Fatal("env PRISM_COST_RECONCILIATION=false should disable")
+	}
+}

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -472,8 +472,17 @@ func NewServer(port string) (*Server, error) {
 
 	// Phase 2 (#644): register the spend observer as a StateMonitor tick hook so per-instance spend
 	// accrues into the budgetengine ledger. Self-throttled (10m estimate cadence) despite the 10s
-	// tick. Loads instances from the state manager; skips Cost Explorer in test mode.
+	// tick. Loads instances from the state manager. Cost Explorer reconciliation is opt-in (config /
+	// PRISM_COST_RECONCILIATION) and only wired when a live AWS manager is present; skipped in test
+	// mode. The billed-cost func is bound from awsManager so the observer stays AWS-free and testable.
 	if spendLedger != nil {
+		opts := spendObserverOptions{
+			reconcileEnabled:  config.CostReconciliationEnabled,
+			reconcileInterval: config.GetCostReconciliationInterval(),
+		}
+		if awsManager != nil {
+			opts.billedCost = awsManager.GetBilledCost
+		}
 		observer := newSpendObserver(spendLedger, func() ([]types.Instance, error) {
 			st, err := stateManager.LoadState()
 			if err != nil {
@@ -484,8 +493,11 @@ func NewServer(port string) (*Server, error) {
 				out = append(out, inst)
 			}
 			return out, nil
-		}, server.testMode)
+		}, server.testMode, opts)
 		stateMonitor.SetTickHook(func() { observer.Observe(context.Background()) })
+		if opts.reconcileEnabled && opts.billedCost != nil {
+			logger.Info("Budget cost reconciliation enabled", "interval", opts.reconcileInterval.String())
+		}
 	}
 
 	// Initialize course manager (v0.14.0 - Issue #45)

--- a/pkg/daemon/spend_observer.go
+++ b/pkg/daemon/spend_observer.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	be "github.com/scttfrdmn/budgetengine"
@@ -19,12 +20,12 @@ import (
 //   - Estimate (cheap, frequent): every accrualInterval, per running instance, append the delta of
 //     a cumulative list-price estimate (HourlyRate × running hours). This is a pure function of the
 //     instance record, so it needs no AWS call.
-//   - Billed reconciliation (authoritative, ~daily): NOT YET IMPLEMENTED. The design and the
-//     checkpoint carry fields for it (LastReconcileAt/ReconciledBilled, spendReconcileInterval), but
-//     Phase 2 ships the estimate feed only. Reconciling against awsManager.GetBilledCost (Cost
-//     Explorer) — with cumulative→delta correction and reversal semantics — lands as a follow-up so
-//     the CE cost/rate-limit handling gets its own focused change. The reversal-based `Source:
-//     "billed"` correction is where it will hook in.
+//   - Billed reconciliation (authoritative, ~daily): OPT-IN (#644 follow-up). When enabled via
+//     config (CostReconciliationEnabled) and a live AWS manager is present, reconcileInstance calls
+//     the injected billedCost (awsManager.GetBilledCost) on the reconcileInterval and replaces the
+//     estimate slice with the authoritative Cost Explorer billed slice (reversal + billed events).
+//     OFF by default; skipped in test/reduced mode and when the per-instance cost-allocation tag is
+//     inactive (keeps the estimate, warns).
 //
 // Cumulative→delta: sources are cumulative but the ledger is delta-append, so the observer keeps a
 // per-instance checkpoint (last cumulative) and appends newCumulative − last, with a unique-per-delta
@@ -48,10 +49,44 @@ type spendObserver struct {
 	loadInst func() ([]types.Instance, error) // returns current instances (from state manager)
 	testMode bool                             // skip Cost Explorer entirely
 	clock    func() time.Time                 // injectable for tests
+
+	// Cost Explorer reconciliation (#644), all off unless explicitly configured.
+	// billedCost is injected (bound awsManager.GetBilledCost) so the CE path is unit-testable with a
+	// spy and nil in reduced mode. reconcileEnabled is the opt-in flag; reconcileInterval throttles.
+	billedCost        func(ctx context.Context, name, region string, since time.Time) (*types.BilledCostResult, error)
+	reconcileEnabled  bool
+	reconcileInterval time.Duration
 }
 
-func newSpendObserver(store *spendStore, loadInst func() ([]types.Instance, error), testMode bool) *spendObserver {
-	return &spendObserver{store: store, loadInst: loadInst, testMode: testMode, clock: time.Now}
+// spendObserverOptions configures reconciliation (Phase 2 shipped without it; this is the #644
+// follow-up). Zero value = estimate-only, matching prior behavior.
+type spendObserverOptions struct {
+	billedCost        func(ctx context.Context, name, region string, since time.Time) (*types.BilledCostResult, error)
+	reconcileEnabled  bool
+	reconcileInterval time.Duration
+}
+
+func newSpendObserver(store *spendStore, loadInst func() ([]types.Instance, error), testMode bool, opts spendObserverOptions) *spendObserver {
+	interval := opts.reconcileInterval
+	if interval <= 0 {
+		interval = spendReconcileInterval
+	}
+	return &spendObserver{
+		store:             store,
+		loadInst:          loadInst,
+		testMode:          testMode,
+		clock:             time.Now,
+		billedCost:        opts.billedCost,
+		reconcileEnabled:  opts.reconcileEnabled,
+		reconcileInterval: interval,
+	}
+}
+
+// reconcilesActive reports whether the CE reconciliation branch may run: opt-in enabled, a live
+// billed-cost func injected (nil in reduced mode), and not test mode. This is the single guard the
+// reconcile path checks — opt-in is the outermost switch.
+func (o *spendObserver) reconcilesActive() bool {
+	return o.reconcileEnabled && o.billedCost != nil && !o.testMode
 }
 
 // Observe runs one accrual pass over all running instances. Called from StateMonitor's tick;
@@ -71,6 +106,9 @@ func (o *spendObserver) Observe(ctx context.Context) {
 			continue // spend accrues only for running, project-attributed instances
 		}
 		o.accrueInstance(ctx, inst, now)
+		if o.reconcilesActive() {
+			o.reconcileInstance(ctx, inst, now)
+		}
 	}
 }
 
@@ -105,6 +143,72 @@ func (o *spendObserver) accrueInstance(ctx context.Context, inst types.Instance,
 	cp.InstanceID = inst.ID
 	cp.LastCumulative = cumulative
 	cp.LastAccrualAt = now
+	_ = o.store.saveCheckpoint(ctx, scope, cp)
+}
+
+// reconcileInstance replaces the estimate slice accrued since the last reconciliation with the
+// authoritative Cost Explorer billed slice, so the ledger converges on real dollars. Throttled to
+// reconcileInterval. Only reachable when reconcilesActive() is true.
+//
+// Netting (all per-instance, since cp.ReconciledBilled — the last billed baseline):
+//
+//	estimateSlice = cp.LastCumulative − cp.ReconciledBilled   // estimate deltas already in the ledger
+//	billedSlice   = res.BilledTotal   − cp.ReconciledBilled   // authoritative for the same window
+//	append  −estimateSlice (source "billed-reversal")  and  +billedSlice (source "billed")
+//	→ ledger total gains (billedSlice − estimateSlice), i.e. the estimate slice is replaced by billed.
+//
+// Unique event IDs make a repeat at the same BilledTotal a no-op delta (idempotent).
+func (o *spendObserver) reconcileInstance(ctx context.Context, inst types.Instance, now time.Time) {
+	scope := projectScope(inst.ProjectID)
+	cp, _ := o.store.checkpoint(ctx, scope, inst.ID)
+
+	if !cp.LastReconcileAt.IsZero() && now.Sub(cp.LastReconcileAt) < o.reconcileInterval {
+		return // throttled
+	}
+
+	res, err := o.billedCost(ctx, inst.Name, inst.Region, inst.LaunchTime)
+	if err != nil {
+		return // fail-open; try again next interval (checkpoint unchanged)
+	}
+	if res == nil || !res.TagActive {
+		// Region-fallback billed cost is not per-instance; reconciling against it would mis-attribute
+		// another instance's spend. Keep the estimate; nudge the operator to activate the tag.
+		log.Printf("Budget reconciliation: cost-allocation tag %q not active for %s; keeping estimate (activate it in AWS Billing for authoritative per-instance cost)", "prism:instance-id", inst.Name)
+		cp.LastReconcileAt = now // still advance throttle so we don't hammer CE every tick
+		_ = o.store.saveCheckpoint(ctx, scope, cp)
+		return
+	}
+
+	estimateSlice := cp.LastCumulative - cp.ReconciledBilled
+	billedSlice := res.BilledTotal - cp.ReconciledBilled
+	if estimateSlice == 0 && billedSlice == 0 {
+		cp.LastReconcileAt = now
+		_ = o.store.saveCheckpoint(ctx, scope, cp)
+		return // nothing to correct
+	}
+
+	if estimateSlice != 0 {
+		_ = o.store.AppendSpend(ctx, scope, be.SpendEvent{
+			ID:           fmt.Sprintf("%s:billed-rev:%d", inst.ID, now.UnixNano()),
+			AllocationID: engineAllocationID,
+			Amount:       -estimateSlice,
+			At:           now,
+			Source:       "billed-reversal",
+		})
+	}
+	if err := o.store.AppendSpend(ctx, scope, be.SpendEvent{
+		ID:           fmt.Sprintf("%s:billed:%d", inst.ID, now.UnixNano()),
+		AllocationID: engineAllocationID,
+		Amount:       billedSlice,
+		At:           now,
+		Source:       "billed",
+	}); err != nil {
+		return // fail-open; the reversal above is idempotent on retry via fresh IDs + baseline unchanged
+	}
+	cp.InstanceID = inst.ID
+	cp.ReconciledBilled = res.BilledTotal
+	cp.LastCumulative = res.BilledTotal // rebase the estimate baseline to billed so future estimate deltas accrue on top
+	cp.LastReconcileAt = now
 	_ = o.store.saveCheckpoint(ctx, scope, cp)
 }
 

--- a/pkg/daemon/spend_observer_test.go
+++ b/pkg/daemon/spend_observer_test.go
@@ -61,7 +61,7 @@ func TestObserver_CumulativeToDelta(t *testing.T) {
 	inst := runningInstance("i-1", "proj-1", 2.0, launched) // $2/hr
 
 	insts := []types.Instance{inst}
-	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true, spendObserverOptions{})
 
 	// t+10h → cumulative $20. Then t+25h → cumulative $50. Deltas: $20, then $30. Total $50.
 	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
@@ -87,7 +87,7 @@ func TestObserver_Throttle(t *testing.T) {
 	s := newTestSpendStore(t)
 	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
-	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true, spendObserverOptions{})
 
 	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
 	obs.Observe(context.Background())
@@ -109,7 +109,7 @@ func TestObserver_IdempotentAcrossRestart(t *testing.T) {
 	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
 
 	at := launched.Add(10 * time.Hour)
-	obs1 := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs1 := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true, spendObserverOptions{})
 	obs1.clock = func() time.Time { return at }
 	obs1.Observe(context.Background())
 
@@ -117,7 +117,7 @@ func TestObserver_IdempotentAcrossRestart(t *testing.T) {
 	// persisted checkpoint means only the genuine delta since the checkpoint accrues — NOT the whole
 	// cumulative again. At t+10h20m, cumulative = $2/hr × 10.333h ≈ $20.67, so the ledger total must
 	// equal the new cumulative (~$20.67), proving no double-count of the first $20.
-	obs2 := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs2 := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true, spendObserverOptions{})
 	obs2.clock = func() time.Time { return at.Add(20 * time.Minute) }
 	obs2.Observe(context.Background())
 
@@ -140,7 +140,7 @@ func TestObserver_SkipsNonRunningAndUnattributed(t *testing.T) {
 	stopped.State = "stopped"
 	noProj := runningInstance("i-np", "", 2.0, launched)
 	insts := []types.Instance{stopped, noProj}
-	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true)
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true, spendObserverOptions{})
 	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
 	obs.Observe(context.Background())
 

--- a/pkg/daemon/spend_reconcile_test.go
+++ b/pkg/daemon/spend_reconcile_test.go
@@ -1,0 +1,150 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// billedSpy is an injectable billedCost func that records call count and returns a canned result.
+type billedSpy struct {
+	calls  int
+	result *types.BilledCostResult
+	err    error
+}
+
+func (s *billedSpy) fn(_ context.Context, _ /*name*/, _ /*region*/ string, _ time.Time) (*types.BilledCostResult, error) {
+	s.calls++
+	return s.result, s.err
+}
+
+func ledgerTotal(t *testing.T, s *spendStore, projectID string) float64 {
+	t.Helper()
+	evs, err := s.Spend(context.Background(), projectScope(projectID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total float64
+	for _, e := range evs {
+		total += e.Amount
+	}
+	return total
+}
+
+// TestReconcile_DisabledNeverCallsCE is the opt-in guarantee: with reconciliation off (the default),
+// GetBilledCost is never invoked, even with a live billedCost func present.
+func TestReconcile_DisabledNeverCallsCE(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
+	spy := &billedSpy{result: &types.BilledCostResult{BilledTotal: 5, TagActive: true}}
+
+	// reconcileEnabled defaults false; even with billedCost set and past any interval, no CE call.
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, false,
+		spendObserverOptions{billedCost: spy.fn, reconcileEnabled: false, reconcileInterval: time.Hour})
+	obs.clock = func() time.Time { return launched.Add(48 * time.Hour) }
+	obs.Observe(context.Background())
+
+	if spy.calls != 0 {
+		t.Fatalf("CE called %d times with reconciliation disabled, want 0", spy.calls)
+	}
+}
+
+// TestReconcile_TestModeNeverCallsCE: test mode is an independent off-switch even when enabled.
+func TestReconcile_TestModeNeverCallsCE(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
+	spy := &billedSpy{result: &types.BilledCostResult{BilledTotal: 5, TagActive: true}}
+
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, true, // testMode
+		spendObserverOptions{billedCost: spy.fn, reconcileEnabled: true, reconcileInterval: time.Hour})
+	obs.clock = func() time.Time { return launched.Add(48 * time.Hour) }
+	obs.Observe(context.Background())
+
+	if spy.calls != 0 {
+		t.Fatalf("CE called %d times in test mode, want 0", spy.calls)
+	}
+}
+
+// TestReconcile_NilBilledCostNeverPanics: reduced mode (nil billedCost) with reconciliation enabled
+// must not call/panic.
+func TestReconcile_NilBilledCostSafe(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
+
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, false,
+		spendObserverOptions{billedCost: nil, reconcileEnabled: true, reconcileInterval: time.Hour})
+	obs.clock = func() time.Time { return launched.Add(48 * time.Hour) }
+	obs.Observe(context.Background()) // must not panic
+}
+
+// TestReconcile_ReplacesEstimateWithBilled: after estimate accrual, an enabled reconcile nets the
+// ledger to the authoritative BilledTotal (estimate slice reversed, billed slice added).
+func TestReconcile_ReplacesEstimateWithBilled(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)} // $2/hr
+	// AWS says the instance actually billed $15 (e.g. a discount/RI made it cheaper than the $20 est).
+	spy := &billedSpy{result: &types.BilledCostResult{BilledTotal: 15, TagActive: true}}
+
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, false,
+		spendObserverOptions{billedCost: spy.fn, reconcileEnabled: true, reconcileInterval: time.Hour})
+
+	// t+10h: estimate accrues $20; then reconcile replaces it with billed $15.
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+
+	if spy.calls != 1 {
+		t.Fatalf("CE calls = %d, want 1", spy.calls)
+	}
+	total := ledgerTotal(t, s, "proj-1")
+	if total < 14.9 || total > 15.1 {
+		t.Fatalf("ledger total = %.2f, want ~15 (billed replaces the $20 estimate)", total)
+	}
+}
+
+// TestReconcile_TagInactiveKeepsEstimate: when the cost-allocation tag isn't active, do NOT reconcile
+// (the region blob isn't per-instance) — the estimate stays.
+func TestReconcile_TagInactiveKeepsEstimate(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
+	spy := &billedSpy{result: &types.BilledCostResult{BilledTotal: 9999, TagActive: false}} // region blob
+
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, false,
+		spendObserverOptions{billedCost: spy.fn, reconcileEnabled: true, reconcileInterval: time.Hour})
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+
+	total := ledgerTotal(t, s, "proj-1")
+	if total < 19.9 || total > 20.1 {
+		t.Fatalf("ledger total = %.2f, want ~20 (estimate kept; tag-inactive billed ignored)", total)
+	}
+}
+
+// TestReconcile_Idempotent: a second reconcile at the same BilledTotal nets zero — no drift.
+func TestReconcile_Idempotent(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	insts := []types.Instance{runningInstance("i-1", "proj-1", 2.0, launched)}
+	spy := &billedSpy{result: &types.BilledCostResult{BilledTotal: 15, TagActive: true}}
+
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return insts, nil }, false,
+		spendObserverOptions{billedCost: spy.fn, reconcileEnabled: true, reconcileInterval: time.Hour})
+
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+	// 2h later (past the 1h reconcile interval): estimate would add ~$4 more, then reconcile back to
+	// the SAME billed $15 → ledger returns to 15, no accumulation.
+	obs.clock = func() time.Time { return launched.Add(12 * time.Hour) }
+	obs.Observe(context.Background())
+
+	total := ledgerTotal(t, s, "proj-1")
+	if total < 14.9 || total > 15.1 {
+		t.Fatalf("ledger total = %.2f, want ~15 (idempotent at same BilledTotal)", total)
+	}
+}


### PR DESCRIPTION
Completes **#644**. The spend ledger can now reconcile its list-price estimates against authoritative AWS Cost Explorer billed cost, so recorded spend converges on real dollars (reflecting RIs/Savings Plans/spot). **Off by default**, configurable frequency.

## Opt-in + configurable
- `daemon_config.json`: `cost_reconciliation_enabled` (default **false**), `cost_reconciliation_interval_minutes` (default **1440** = daily).
- Env overrides: `PRISM_COST_RECONCILIATION=true`, `PRISM_COST_RECONCILIATION_INTERVAL=6h` (env > file > default).
- Interval **clamped to a 1-hour floor** — CE costs ~$0.01/call (1–2 per instance), is rate-limited, and lags ~a day, so a tiny interval can't cause runaway spend.

## How it works
- The observer's `reconcileInstance` runs on the configured interval and **replaces the estimate slice** accrued since the last reconcile with the authoritative billed slice (a reversal event + a billed event, unique IDs → idempotent). The frequent, free estimate feed continues between reconciliations.
- **Three converging off-switches, opt-in outermost:** reconcile only when `enabled` AND a live billed-cost func is present (nil in reduced mode) AND not test mode.
- **Tag-inactive case:** when the per-instance `prism:instance-id` cost-allocation tag isn't activated in AWS Billing, `GetBilledCost` returns a region-wide total (not per-instance) — reconciliation **skips and keeps the estimate**, logging a nudge to activate the tag.

## Testability
`GetBilledCost` is on the concrete `*aws.Manager` (not an interface), so it's injected into the observer as a **bound function value** (matching the existing `loadInst`/`clock` DI). Tests use a spy — no AWS.

## Verification
- Unit: **disabled/test-mode/nil-manager → CE never called** (the opt-in guarantee); reconcile nets the ledger to `BilledTotal`; tag-inactive keeps estimate; idempotent double-reconcile; config defaults/floor/env override. Phase 1/2 budget tests stay green.
- `go build`/`vet`/`test` both modules, `gofmt`, `govulncheck` clean.
- Live smoke: daemon boots clean with reconciliation **off by default** (no CE, no reconcile log) and with the env enabled (no panic).

Closes #644.