### PR TITLE
chore(deps): bump budgetengine to v0.2.0 (Phase 3a)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
-	github.com/scttfrdmn/budgetengine v0.1.0
+	github.com/scttfrdmn/budgetengine v0.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
-github.com/scttfrdmn/budgetengine v0.1.0 h1:vphN+PEXT8QpEVW72ztNilYz1cL47bZLiTWY+/ApmDQ=
-github.com/scttfrdmn/budgetengine v0.1.0/go.mod h1:pNdKHOUFCnw7uD2locx5oqCWD2kb08/240H4RAkn9u0=
+github.com/scttfrdmn/budgetengine v0.2.0 h1:7yDpCBQQMwWutYl0WfEDBg2SA22NOdQBrqhiNKo4jiI=
+github.com/scttfrdmn/budgetengine v0.2.0/go.mod h1:pNdKHOUFCnw7uD2locx5oqCWD2kb08/240H4RAkn9u0=
 github.com/scttfrdmn/substrate v0.48.0 h1:Apumf1EsTK5Sz9MLnCLZ6pQcyj/ChneCmun39AqJ0jI=
 github.com/scttfrdmn/substrate v0.48.0/go.mod h1:gKkftVt2MxQ465Rs/Na4SsEvm/SJMBypfCGmdKlvfro=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=


### PR DESCRIPTION
Phase 3a of #645. Bumps `github.com/scttfrdmn/budgetengine` v0.1.0 → **v0.2.0**, which adds additive, backward-compatible line-item fields to `SpendEvent` (`ResourceID`, `Compute`/`Storage`/`Network`) for per-resource cost breakdown.

No prism code change in this PR — the fold/CheckLaunch use only `Amount`, so existing behavior is unchanged. The spend observer starts populating the new fields in **Phase 3b (#652)**, which unlocks re-deriving the cost-breakdown/report DTOs from the real ledger (3d) as part of retiring BudgetTracker.

Verified: build + budget tests (both modules), govulncheck clean. Closes #651.