### PR TITLE
feat(budget): spend observer records per-resource line items (Phase 3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Spend ledger records per-resource, per-component line items (#652).** The spend observer now
+  populates the v0.2.0 `SpendEvent` line-item fields: each event carries `ResourceID` (instance id)
+  and an **un-blended** split of `Compute` and `Storage` (Network unmodeled) that sums to `Amount`.
+  Compute and storage accrue on **independent clocks** — compute on running-hours (it stops when the
+  instance stops), storage on total-hours at the standard EBS rate (it persists and bills while
+  stopped). Consequently the observer now also accrues for stopped-but-storage-bearing instances, not
+  only running ones. This gives the ledger the detail Phase 3d aggregates into the cost-breakdown /
+  resource-usage / report DTOs. Reconciliation now tracks estimate and billed baselines in their own
+  units so the two never conflate.
+
 ### Added
 - **Opt-in Cost Explorer billed-cost reconciliation (#644).** The budget spend ledger can now
   reconcile its list-price estimates against authoritative AWS Cost Explorer billed cost, so a

--- a/pkg/daemon/spend_lineitem_test.go
+++ b/pkg/daemon/spend_lineitem_test.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// instanceWithStorage builds a running instance carrying a root volume, for line-item tests.
+func instanceWithStorage(id, projectID string, hourly, storageGB float64, launched time.Time) types.Instance {
+	return types.Instance{
+		ID: id, ProjectID: projectID, State: "running",
+		HourlyRate: hourly, StorageGB: storageGB, LaunchTime: launched,
+	}
+}
+
+// TestObserver_LineItemsSplitComputeStorage: a running instance with a root volume produces events
+// carrying non-zero Compute AND Storage, ResourceID = instance ID, and Compute+Storage == Amount.
+func TestObserver_LineItemsSplitComputeStorage(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inst := instanceWithStorage("i-1", "proj-1", 2.0, 100, launched) // $2/hr compute, 100GB
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return []types.Instance{inst}, nil }, true, spendObserverOptions{})
+
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	if len(evs) != 1 {
+		t.Fatalf("want 1 event, got %d", len(evs))
+	}
+	e := evs[0]
+	if e.ResourceID != "i-1" {
+		t.Fatalf("ResourceID = %q, want i-1", e.ResourceID)
+	}
+	// compute = $2 × 10h = $20; storage = 100GB × $0.10/730 × 10h ≈ $0.137
+	if e.Compute < 19.9 || e.Compute > 20.1 {
+		t.Fatalf("Compute = %.4f, want ~20", e.Compute)
+	}
+	if e.Storage <= 0 {
+		t.Fatalf("Storage = %.4f, want > 0", e.Storage)
+	}
+	if diff := e.Amount - (e.Compute + e.Storage); diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("Amount (%.6f) != Compute+Storage (%.6f)", e.Amount, e.Compute+e.Storage)
+	}
+}
+
+// TestObserver_StorageAccruesWhileStopped: a STOPPED instance with a volume still accrues storage
+// (EBS bills while stopped) but zero compute — the independent-clock guarantee.
+func TestObserver_StorageAccruesWhileStopped(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inst := instanceWithStorage("i-1", "proj-1", 2.0, 100, launched)
+	inst.State = "stopped" // no compute; storage persists
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return []types.Instance{inst}, nil }, true, spendObserverOptions{})
+
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	if len(evs) != 1 {
+		t.Fatalf("stopped instance with storage should accrue 1 event, got %d", len(evs))
+	}
+	e := evs[0]
+	if e.Compute != 0 {
+		t.Fatalf("Compute = %.4f, want 0 (instance stopped)", e.Compute)
+	}
+	if e.Storage <= 0 {
+		t.Fatalf("Storage = %.4f, want > 0 (EBS bills while stopped)", e.Storage)
+	}
+	if e.Amount != e.Storage {
+		t.Fatalf("Amount = %.4f, want == Storage %.4f", e.Amount, e.Storage)
+	}
+}
+
+// TestObserver_StoppedNoStorageAccruesNothing: a stopped instance with no volume accrues nothing
+// (matches the pre-3b skip behavior for the compute-only case).
+func TestObserver_StoppedNoStorageAccruesNothing(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inst := instanceWithStorage("i-1", "proj-1", 2.0, 0, launched)
+	inst.State = "stopped"
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return []types.Instance{inst}, nil }, true, spendObserverOptions{})
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) }
+	obs.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	if len(evs) != 0 {
+		t.Fatalf("stopped + no storage should accrue nothing, got %d events", len(evs))
+	}
+}
+
+// TestObserver_ComputeStopsStorageContinues: running-hours from StateHistory — compute freezes at the
+// stop transition while storage keeps growing on the total-hours clock.
+func TestObserver_ComputeStopsStorageContinues(t *testing.T) {
+	s := newTestSpendStore(t)
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inst := instanceWithStorage("i-1", "proj-1", 2.0, 100, launched)
+	inst.State = "stopped"
+	// Ran for the first 4h, then stopped.
+	inst.StateHistory = []types.StateTransition{
+		{ToState: "running", Timestamp: launched},
+		{ToState: "stopped", Timestamp: launched.Add(4 * time.Hour)},
+	}
+	obs := newSpendObserver(s, func() ([]types.Instance, error) { return []types.Instance{inst}, nil }, true, spendObserverOptions{})
+
+	obs.clock = func() time.Time { return launched.Add(10 * time.Hour) } // 10h elapsed, 4h running
+	obs.Observe(context.Background())
+
+	evs, _ := s.Spend(context.Background(), projectScope("proj-1"))
+	e := evs[0]
+	// compute = $2 × 4 running-hours = $8 (NOT $20); storage = 100GB × rate × 10 total-hours.
+	if e.Compute < 7.9 || e.Compute > 8.1 {
+		t.Fatalf("Compute = %.4f, want ~8 (4 running-hours, not 10 wall-clock)", e.Compute)
+	}
+	if e.Storage <= 0 {
+		t.Fatalf("Storage = %.4f, want > 0 (accrues full 10h)", e.Storage)
+	}
+}

--- a/pkg/daemon/spend_observer.go
+++ b/pkg/daemon/spend_observer.go
@@ -20,12 +20,15 @@ import (
 //   - Estimate (cheap, frequent): every accrualInterval, per running instance, append the delta of
 //     a cumulative list-price estimate (HourlyRate × running hours). This is a pure function of the
 //     instance record, so it needs no AWS call.
-//   - Billed reconciliation (authoritative, ~daily): OPT-IN (#644 follow-up). When enabled via
-//     config (CostReconciliationEnabled) and a live AWS manager is present, reconcileInstance calls
-//     the injected billedCost (awsManager.GetBilledCost) on the reconcileInterval and replaces the
-//     estimate slice with the authoritative Cost Explorer billed slice (reversal + billed events).
-//     OFF by default; skipped in test/reduced mode and when the per-instance cost-allocation tag is
-//     inactive (keeps the estimate, warns).
+//   - Billed reconciliation (authoritative, ~daily): OPT-IN (#644 follow-up). For a plain on-demand
+//     instance the estimate already matches the bill to the penny (known rate × known time), so
+//     reconciliation is a near-no-op. Its purpose is the cases where list-price and the actual bill
+//     genuinely diverge: spot pricing, Reserved Instances / Savings Plans, credits/EDP/negotiated
+//     rates, and storage nuances (snapshots, provisioned IOPS, transfer). When enabled and a live AWS
+//     manager is present, reconcileInstance calls billedCost (awsManager.GetBilledCost) on the
+//     reconcileInterval and replaces the estimate slice with the authoritative Cost Explorer figure
+//     (reversal + billed events). OFF by default; skipped in test/reduced mode and when the
+//     per-instance cost-allocation tag is inactive (keeps the estimate, warns).
 //
 // Cumulative→delta: sources are cumulative but the ledger is delta-append, so the observer keeps a
 // per-instance checkpoint (last cumulative) and appends newCumulative − last, with a unique-per-delta
@@ -102,13 +105,27 @@ func (o *spendObserver) Observe(ctx context.Context) {
 	}
 	now := o.clock()
 	for _, inst := range instances {
-		if inst.ProjectID == "" || inst.State != "running" {
-			continue // spend accrues only for running, project-attributed instances
+		if inst.ProjectID == "" || !accruesSpend(inst) {
+			continue
 		}
 		o.accrueInstance(ctx, inst, now)
 		if o.reconcilesActive() {
 			o.reconcileInstance(ctx, inst, now)
 		}
+	}
+}
+
+// accruesSpend reports whether an instance still incurs cost: a running instance (compute+storage),
+// or a stopped one that still has a root volume (storage persists and bills while stopped, #652).
+// Terminated instances accrue nothing.
+func accruesSpend(inst types.Instance) bool {
+	switch inst.State {
+	case "terminated", "shutting-down":
+		return false
+	case "running":
+		return true
+	default: // stopped / stopping / hibernated — still billed for storage if a volume exists
+		return inst.StorageGB > 0
 	}
 }
 
@@ -121,10 +138,20 @@ func (o *spendObserver) accrueInstance(ctx context.Context, inst types.Instance,
 		return // throttled
 	}
 
-	cumulative := estimateCumulativeCost(inst, now)
-	delta := cumulative - cp.LastCumulative
+	// Per-component cumulatives on independent clocks (compute stops when the instance stops;
+	// storage bills for the whole lifetime). Deltas are each component's growth since the checkpoint.
+	compCum, storeCum := estimateComponents(inst, now)
+	deltaCompute := compCum - cp.LastComputeCum
+	deltaStorage := storeCum - cp.LastStorageCum
+	if deltaCompute < 0 {
+		deltaCompute = 0 // guard against any non-monotonic estimate
+	}
+	if deltaStorage < 0 {
+		deltaStorage = 0
+	}
+	delta := deltaCompute + deltaStorage
 	if delta <= 0 {
-		// No new cost (or a stale/decreasing estimate) — just advance the throttle timestamp.
+		// No new cost — just advance the throttle timestamp.
 		cp.LastAccrualAt = now
 		_ = o.store.saveCheckpoint(ctx, scope, cp)
 		return
@@ -136,12 +163,17 @@ func (o *spendObserver) accrueInstance(ctx context.Context, inst types.Instance,
 		Amount:       delta,
 		At:           now,
 		Source:       "estimate",
+		ResourceID:   inst.ID,
+		Compute:      deltaCompute,
+		Storage:      deltaStorage,
+		// Network unmodeled (0).
 	}
 	if err := o.store.AppendSpend(ctx, scope, ev); err != nil {
 		return // fail-open; retry next tick (checkpoint unchanged, so no lost spend)
 	}
 	cp.InstanceID = inst.ID
-	cp.LastCumulative = cumulative
+	cp.LastComputeCum = compCum
+	cp.LastStorageCum = storeCum
 	cp.LastAccrualAt = now
 	_ = o.store.saveCheckpoint(ctx, scope, cp)
 }
@@ -179,7 +211,13 @@ func (o *spendObserver) reconcileInstance(ctx context.Context, inst types.Instan
 		return
 	}
 
-	estimateSlice := cp.LastCumulative - cp.ReconciledBilled
+	// Slices are measured in their own units from the last reconcile: the estimate accrued into the
+	// ledger since then (current total estimate − estimate at last reconcile) vs. the authoritative
+	// billed for the same window (billed − billed at last reconcile). Replacing one with the other
+	// nets the ledger to billed without ever conflating estimate and billed dollars.
+	compCum, storeCum := estimateComponents(inst, now)
+	estimateNow := compCum + storeCum
+	estimateSlice := estimateNow - cp.ReconciledEstimate
 	billedSlice := res.BilledTotal - cp.ReconciledBilled
 	if estimateSlice == 0 && billedSlice == 0 {
 		cp.LastReconcileAt = now
@@ -205,25 +243,76 @@ func (o *spendObserver) reconcileInstance(ctx context.Context, inst types.Instan
 	}); err != nil {
 		return // fail-open; the reversal above is idempotent on retry via fresh IDs + baseline unchanged
 	}
+	// Advance BOTH reconcile baselines to this point (in their own units). The per-component accrual
+	// baselines (LastComputeCum/LastStorageCum) are deliberately left untouched — the estimate feed
+	// keeps accruing monotonically; reconciliation only overlays a correction on top of it.
 	cp.InstanceID = inst.ID
+	cp.ReconciledEstimate = estimateNow
 	cp.ReconciledBilled = res.BilledTotal
-	cp.LastCumulative = res.BilledTotal // rebase the estimate baseline to billed so future estimate deltas accrue on top
 	cp.LastReconcileAt = now
 	_ = o.store.saveCheckpoint(ctx, scope, cp)
 }
 
-// estimateCumulativeCost is a self-contained, monotonic list-price estimate of an instance's spend
-// since launch: HourlyRate × hours since LaunchTime. It intentionally does not read the possibly-
-// stale cached CurrentSpend; it recomputes so successive observations produce a clean cumulative
-// series the delta logic can difference. (Running-vs-stopped nuance and storage-only rates are a
-// refinement for the billed-reconciliation path; this estimate is the coarse frequent feed.)
-func estimateCumulativeCost(inst types.Instance, now time.Time) float64 {
-	if inst.LaunchTime.IsZero() || inst.HourlyRate <= 0 {
+// ebsGBMonthRate is the standard gp3 EBS storage price ($/GB-month), mirroring the value used in
+// pkg/aws/ami_cost_analyzer.go. Coarse but fine for the estimate feed — billed reconciliation
+// corrects the authoritative total. hoursPerMonth converts it to $/GB-hour.
+const (
+	ebsGBMonthRate = 0.10
+	hoursPerMonth  = 730.0
+)
+
+// estimateComponents is a self-contained, monotonic list-price estimate of an instance's cumulative
+// cost since launch, split into compute and storage on INDEPENDENT clocks (#652):
+//
+//   - compute = HourlyRate × running-hours — compute is billed only while the instance is running,
+//     so it stops accruing when the instance stops (from StateHistory).
+//   - storage = RootVolumeGB × ($/GB-hour) × total-hours — EBS persists and bills for the whole
+//     lifetime, running or stopped.
+//
+// This mirrors pkg/aws/manager.go:calculateActualCosts (running-hours compute vs total-hours
+// storage) but stays self-contained (no pkg/aws dependency), recomputing from the instance record so
+// successive observations difference into clean per-component deltas.
+func estimateComponents(inst types.Instance, now time.Time) (compute, storage float64) {
+	if inst.LaunchTime.IsZero() {
+		return 0, 0
+	}
+	totalHours := now.Sub(inst.LaunchTime).Hours()
+	if totalHours <= 0 {
+		return 0, 0
+	}
+	if inst.HourlyRate > 0 {
+		compute = inst.HourlyRate * runningHours(inst, now)
+	}
+	if inst.StorageGB > 0 {
+		storage = inst.StorageGB * (ebsGBMonthRate / hoursPerMonth) * totalHours
+	}
+	return compute, storage
+}
+
+// runningHours sums the time the instance has spent in the "running" state since launch, from its
+// StateHistory. When there's no history, it falls back to total elapsed time if currently running,
+// else 0 (a stopped instance with no history accrues no compute). Storage does not use this — it
+// bills for the full lifetime regardless of state.
+func runningHours(inst types.Instance, now time.Time) float64 {
+	if len(inst.StateHistory) == 0 {
+		if inst.State == "running" {
+			return now.Sub(inst.LaunchTime).Hours()
+		}
 		return 0
 	}
-	hours := now.Sub(inst.LaunchTime).Hours()
-	if hours <= 0 {
-		return 0
+	var hours float64
+	// Walk transitions; accumulate time spent in "running" between each transition and the next.
+	for i, tr := range inst.StateHistory {
+		if tr.ToState != "running" {
+			continue
+		}
+		end := now
+		if i+1 < len(inst.StateHistory) {
+			end = inst.StateHistory[i+1].Timestamp
+		}
+		if end.After(tr.Timestamp) {
+			hours += end.Sub(tr.Timestamp).Hours()
+		}
 	}
-	return inst.HourlyRate * hours
+	return hours
 }

--- a/pkg/daemon/spend_store.go
+++ b/pkg/daemon/spend_store.go
@@ -31,11 +31,17 @@ func projectScope(projectID string) be.Scope {
 // convert a cumulative estimate/billed figure into an append-only delta (newCumulative − last).
 // Persisted as its own seam record (durable across daemon restart) to avoid re-appending spend.
 type spendCheckpoint struct {
-	InstanceID       string    `json:"instance_id"`
-	LastCumulative   float64   `json:"last_cumulative"`   // last cumulative estimate appended
-	LastAccrualAt    time.Time `json:"last_accrual_at"`   // throttle: last estimate append
-	LastReconcileAt  time.Time `json:"last_reconcile_at"` // throttle: last billed reconciliation
-	ReconciledBilled float64   `json:"reconciled_billed"` // last authoritative billed total applied
+	InstanceID string `json:"instance_id"`
+	// Per-component estimate baselines — monotonic cumulative estimate by component; the accrual
+	// path measures each delta from these and advances them. NEVER rebased by reconciliation (that
+	// would mix estimate and billed units). Their sum is the total cumulative estimate.
+	LastComputeCum float64   `json:"last_compute_cum"` // cumulative compute estimate (#652)
+	LastStorageCum float64   `json:"last_storage_cum"` // cumulative storage estimate (#652)
+	LastAccrualAt  time.Time `json:"last_accrual_at"`  // throttle: last estimate append
+	// Reconciliation baselines, kept in their OWN units so estimateSlice/billedSlice never conflate:
+	LastReconcileAt    time.Time `json:"last_reconcile_at"`   // throttle: last billed reconciliation
+	ReconciledEstimate float64   `json:"reconciled_estimate"` // total estimate at last reconcile (#652)
+	ReconciledBilled   float64   `json:"reconciled_billed"`   // authoritative billed total at last reconcile
 }
 
 // spendStore adapts two seam stores (spend events + per-instance checkpoints) into the engine's


### PR DESCRIPTION
Phase 3b of #645. The spend observer now populates the v0.2.0 `SpendEvent` line-item fields, giving the ledger the per-resource detail Phase 3d aggregates into the cost-breakdown / resource-usage / report DTOs.

## What
Each estimate event carries `ResourceID` (instance id) and an **un-blended** split of `Compute` and `Storage` (Network unmodeled) that sums to `Amount`.

**Compute and storage accrue on independent clocks** — because they have independent lifecycles:
- `compute = HourlyRate × running-hours` (from `StateHistory`) — **stops when the instance stops**.
- `storage = StorageGB × $0.10/GB-mo × total-hours` — **persists and bills while stopped** (EBS).

So the observer now also accrues for **stopped instances that still have storage** (not only running ones); a stopped, storage-less instance still accrues nothing.

## Checkpoint rework
Separated the per-component estimate baselines (`LastComputeCum`/`LastStorageCum`, never rebased) from the reconciliation baselines (`ReconciledEstimate`/`ReconciledBilled`, in their own units), so estimate and billed slices never conflate. This also fixes the reconcile-idempotency interaction the component split would otherwise have broken.

## Framing correction
For plain on-demand instances the estimate matches the bill to the penny (known rate × known time). Reconciliation (#644) exists for genuine divergence — spot, RIs/Savings Plans, credits, storage nuances — not arithmetic drift. Comments updated to say so.

## Verification
- New tests: compute+storage sums to Amount + ResourceID set; storage accrues while stopped; stopped+no-storage → nothing; compute freezes at stop while storage continues (running-hours vs total-hours). All prior observer/reconcile/launch-gate tests green (zero-storage instances → unchanged totals).
- `go build`/`vet`/`test` both modules, `gofmt`, `govulncheck` clean.

Closes #652.