### PR TITLE
feat(budget): cost breakdown/usage/trends/report on the spend ledger (Phase 3d, #654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Cost breakdown / resource usage / trends / monthly report now aggregate the real spend ledger
+  (Phase 3d, #654).** The four cost-analytics surfaces that returned zeros after Phase 3c are computed
+  from the `budgetengine` spend ledger in a new `pkg/daemon/cost_aggregation.go`. Everything derives
+  from one primitive, `ledgerCostSeries`, a day-bucketed fold over the project's events: `estimate`
+  events (which carry `ResourceID` + un-blended `Compute`/`Storage`, #652) attribute per-instance
+  per-day; `billed`/`billed-reversal` reconciliation events (no `ResourceID`) fold into the day's
+  project total only. From that series: `GET /projects/{id}/costs` returns a populated
+  `ProjectCostBreakdown` (per-instance compute/storage + running/stopped hours from `StateHistory`,
+  synthesized per-instance root-volume storage lines); `GET /projects/{id}/usage` returns real
+  `ProjectResourceUsage` (active/total counts, compute hours, idle savings); the monthly report and
+  budget-history endpoints render the real series; and `BudgetStatus.BurnRate` is now populated (via
+  the existing `BurnRateCalculator`). **`GET /cost/trends`** now emits the `{date, spent, budget}`
+  shape the CLI history table actually renders (the pre-3c stub emitted `CostDataPoint`, which the CLI
+  never parsed, so `prism budget history` was always blank). The Manager's `GetProjectCostBreakdown`/
+  `GetProjectResourceUsage` stubs are removed — the daemon owns cost aggregation, keeping `pkg/project`
+  ledger-free. `BudgetStatus.Surplus` stays nil pending banking/rollover (Phase 3e, #655).
 - **Budget status is now derived from the spend ledger, not the retired tracker (Phase 3c, #653).**
   The daemon computes `BudgetStatus` (`pkg/daemon/budget_status.go`) directly from the `budgetengine`
   spend ledger + the project's embedded budget plan: `SpentAmount` is the ledger fold (falling back to

--- a/pkg/daemon/budget_status.go
+++ b/pkg/daemon/budget_status.go
@@ -66,7 +66,7 @@ func (s *Server) budgetStatus(ctx context.Context, projectID string) (*project.B
 		SpentAmount:     spent,
 		RemainingBudget: remaining,
 		SpentPercentage: spentPct,
-		// BurnRate/Surplus are ledger-derived analytics deferred to 3d/3e (#654/#655).
+		// Surplus (banking/rollover) stays nil — Phase 3e (#655). BurnRate is populated below (3d).
 		ActiveAlerts:     []string{},
 		TriggeredActions: []string{},
 		LastUpdated:      now,
@@ -80,6 +80,18 @@ func (s *Server) budgetStatus(ctx context.Context, projectID string) (*project.B
 			days := int(bs.ProjectedZeroDate.Sub(now).Hours() / 24)
 			status.DaysUntilBudgetExhausted = &days
 		}
+	}
+
+	// Phase 3d (#654): period-aware burn rate from the ledger-derived cost-history series. Reuses the
+	// existing BurnRateCalculator (the same analytics the retired tracker fed). The 7-day trailing rate
+	// needs a few weeks of history, so pull a 90-day window; ComputeBurnRate re-clips to the period.
+	if series, err := s.ledgerCostSeries(ctx, projectID, now.AddDate(0, 0, -90), now); err == nil && len(series) >= 2 {
+		allocation := totalBudget
+		if budget.MonthlyAmount > 0 {
+			allocation = budget.MonthlyAmount
+		}
+		calc := &project.BurnRateCalculator{}
+		status.BurnRate = calc.ComputeBurnRate(series, budget.BudgetPeriod, budget.StartDate, allocation)
 	}
 
 	return status, nil

--- a/pkg/daemon/cost_aggregation.go
+++ b/pkg/daemon/cost_aggregation.go
@@ -1,0 +1,410 @@
+package daemon
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	be "github.com/scttfrdmn/budgetengine"
+	"github.com/scttfrdmn/prism/pkg/project"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// Phase 3d (#654): the cost-analytics surfaces (cost breakdown, resource usage, cost trends, monthly
+// report, and BudgetStatus.BurnRate) are aggregated here, in the daemon, from the budgetengine spend
+// ledger — replacing the Phase 3c stubs that returned zeros. Everything derives from one primitive,
+// ledgerCostSeries, a day-bucketed fold over s.spendLedger.Spend(projectScope(id)).
+//
+// The observer (#652) stamps each estimate SpendEvent with ResourceID = instance ID and an un-blended
+// Compute/Storage split, so per-instance / per-day attribution is a pure fold — no AWS calls. Two
+// caveats, both documented at their sites:
+//   - billed / billed-reversal events (Cost Explorer reconciliation) carry NO ResourceID or component
+//     split, so they fold into the day's project-level total only, not per-instance lines.
+//   - instances that have since terminated are gone from state; their events fall back to the raw
+//     ResourceID for a name and "unknown" for the type.
+
+// ledgerCostSeries folds the project's spend ledger into an ascending, day-bucketed cost series over
+// [start, end). Each point's TotalCost is the running cumulative spend (the burn-rate/history helpers
+// difference TotalCost between points), and DailyCost is that day's spend. InstanceCosts/StorageCosts
+// hold the per-instance lines for the day (estimate events only). Days with no accrual produce no
+// point.
+func (s *Server) ledgerCostSeries(ctx context.Context, projectID string, start, end time.Time) ([]project.CostDataPoint, error) {
+	if s.spendLedger == nil || projectID == "" {
+		return nil, nil
+	}
+	events, err := s.spendLedger.Spend(ctx, projectScope(projectID))
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	instByID := s.instancesByID()
+
+	buckets := map[string]*dayBucket{}
+	for _, ev := range events {
+		if ev.At.Before(start) || !ev.At.Before(end) {
+			continue
+		}
+		bucketForDay(buckets, ev.At.UTC().Truncate(24*time.Hour)).add(ev, instByID)
+	}
+	if len(buckets) == 0 {
+		return nil, nil
+	}
+	return emitSeries(buckets), nil
+}
+
+// instancesByID loads the current instance map (ResourceID → instance) for naming/typing per-instance
+// lines. Empty when no state manager is wired (unit tests) or state is unreadable.
+func (s *Server) instancesByID() map[string]types.Instance {
+	if s.stateManager == nil {
+		return map[string]types.Instance{}
+	}
+	st, err := s.stateManager.LoadState()
+	if err != nil {
+		return map[string]types.Instance{}
+	}
+	return st.Instances
+}
+
+// dayBucket accumulates one UTC day's spend: the project-level dailyCost plus per-instance compute /
+// storage lines (keyed by instance ID).
+type dayBucket struct {
+	day       time.Time
+	dailyCost float64
+	instances map[string]*types.InstanceCost
+	storage   map[string]*types.StorageCost
+}
+
+// bucketForDay returns (creating if needed) the bucket for the given day.
+func bucketForDay(buckets map[string]*dayBucket, day time.Time) *dayBucket {
+	key := day.Format("2006-01-02")
+	b := buckets[key]
+	if b == nil {
+		b = &dayBucket{
+			day:       day,
+			instances: map[string]*types.InstanceCost{},
+			storage:   map[string]*types.StorageCost{},
+		}
+		buckets[key] = b
+	}
+	return b
+}
+
+// add folds one SpendEvent into the bucket. Amount is authoritative for the project total (spend > 0,
+// reversals < 0). Only line-item-bearing events (estimate accruals, ResourceID set) attribute per
+// instance; billed / billed-reversal events have no ResourceID and fold into dailyCost only.
+func (b *dayBucket) add(ev be.SpendEvent, instByID map[string]types.Instance) {
+	b.dailyCost += ev.Amount
+	if ev.ResourceID == "" {
+		return
+	}
+
+	ic := b.instances[ev.ResourceID]
+	if ic == nil {
+		name, typ := ev.ResourceID, "unknown"
+		if inst, ok := instByID[ev.ResourceID]; ok {
+			if inst.Name != "" {
+				name = inst.Name
+			}
+			if inst.InstanceType != "" {
+				typ = inst.InstanceType
+			}
+		}
+		ic = &types.InstanceCost{InstanceName: name, InstanceType: typ}
+		b.instances[ev.ResourceID] = ic
+	}
+	ic.ComputeCost += ev.Compute
+	ic.StorageCost += ev.Storage
+	ic.TotalCost += ev.Compute + ev.Storage
+
+	if ev.Storage > 0 {
+		b.storageLine(ev.ResourceID, instByID).Cost += ev.Storage
+	}
+}
+
+// storageLine returns (creating if needed) the synthesized per-instance root-volume line. Events
+// don't key by volume, so size comes from state when the instance still exists.
+func (b *dayBucket) storageLine(resourceID string, instByID map[string]types.Instance) *types.StorageCost {
+	sc := b.storage[resourceID]
+	if sc != nil {
+		return sc
+	}
+	name := resourceID + "-root"
+	var sizeGB float64
+	if inst, ok := instByID[resourceID]; ok {
+		if inst.Name != "" {
+			name = inst.Name + "-root"
+		}
+		sizeGB = inst.StorageGB
+	}
+	sc = &types.StorageCost{VolumeName: name, VolumeType: "gp3", SizeGB: sizeGB, CostPerGB: ebsGBMonthRate}
+	b.storage[resourceID] = sc
+	return sc
+}
+
+// emitSeries orders the buckets ascending by day and emits points with a running cumulative
+// TotalCost (the burn-rate/history helpers difference TotalCost between points).
+func emitSeries(buckets map[string]*dayBucket) []project.CostDataPoint {
+	keys := make([]string, 0, len(buckets))
+	for k := range buckets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	series := make([]project.CostDataPoint, 0, len(keys))
+	var cumulative float64
+	for _, k := range keys {
+		b := buckets[k]
+		cumulative += b.dailyCost
+
+		instances := make([]types.InstanceCost, 0, len(b.instances))
+		for _, ic := range b.instances {
+			instances = append(instances, *ic)
+		}
+		sort.Slice(instances, func(i, j int) bool { return instances[i].InstanceName < instances[j].InstanceName })
+
+		storage := make([]types.StorageCost, 0, len(b.storage))
+		for _, sc := range b.storage {
+			storage = append(storage, *sc)
+		}
+		sort.Slice(storage, func(i, j int) bool { return storage[i].VolumeName < storage[j].VolumeName })
+
+		series = append(series, project.CostDataPoint{
+			Timestamp:     b.day,
+			TotalCost:     cumulative,
+			DailyCost:     b.dailyCost,
+			InstanceCosts: instances,
+			StorageCosts:  storage,
+		})
+	}
+	return series
+}
+
+// costBreakdown aggregates the day-bucketed series across [start, end) into a single
+// ProjectCostBreakdown: one InstanceCost per instance (component costs + running/stopped hours from
+// StateHistory) and one synthesized per-instance StorageCost line.
+func (s *Server) costBreakdown(ctx context.Context, projectID string, start, end time.Time) (*types.ProjectCostBreakdown, error) {
+	series, err := s.ledgerCostSeries(ctx, projectID, start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	instByID := s.instancesByID()
+
+	// Aggregate per instance name (breakdown lines are keyed by name, matching the DTO) and per volume.
+	instAgg := map[string]*types.InstanceCost{}
+	storageAgg := map[string]*types.StorageCost{}
+	var total float64
+	for _, pt := range series {
+		total += pt.DailyCost
+		for _, ic := range pt.InstanceCosts {
+			agg := instAgg[ic.InstanceName]
+			if agg == nil {
+				agg = &types.InstanceCost{InstanceName: ic.InstanceName, InstanceType: ic.InstanceType}
+				instAgg[ic.InstanceName] = agg
+			}
+			agg.ComputeCost += ic.ComputeCost
+			agg.StorageCost += ic.StorageCost
+			agg.TotalCost += ic.TotalCost
+		}
+		for _, sc := range pt.StorageCosts {
+			agg := storageAgg[sc.VolumeName]
+			if agg == nil {
+				agg = &types.StorageCost{VolumeName: sc.VolumeName, VolumeType: sc.VolumeType, SizeGB: sc.SizeGB, CostPerGB: sc.CostPerGB}
+				storageAgg[sc.VolumeName] = agg
+			}
+			agg.Cost += sc.Cost
+		}
+	}
+
+	// Fill running/stopped hours from each instance's StateHistory clipped to the window. Matched by
+	// name (the breakdown key); instances gone from state simply report zero hours.
+	windowHours := end.Sub(start).Hours()
+	for _, inst := range instByID {
+		agg := instAgg[inst.Name]
+		if agg == nil {
+			continue
+		}
+		rh := runningHoursInWindow(inst, start, end)
+		agg.RunningHours = rh
+		stopped := windowHours - rh
+		if stopped < 0 {
+			stopped = 0
+		}
+		agg.StoppedHours = stopped
+		// HibernatedHours is not separately tracked from StateHistory; left 0 (best-effort).
+	}
+
+	instances := make([]types.InstanceCost, 0, len(instAgg))
+	for _, ic := range instAgg {
+		instances = append(instances, *ic)
+	}
+	sort.Slice(instances, func(i, j int) bool { return instances[i].InstanceName < instances[j].InstanceName })
+
+	storage := make([]types.StorageCost, 0, len(storageAgg))
+	for _, sc := range storageAgg {
+		storage = append(storage, *sc)
+	}
+	sort.Slice(storage, func(i, j int) bool { return storage[i].VolumeName < storage[j].VolumeName })
+
+	return &types.ProjectCostBreakdown{
+		ProjectID:     projectID,
+		TotalCost:     total,
+		InstanceCosts: instances,
+		StorageCosts:  storage,
+		PeriodStart:   start,
+		PeriodEnd:     end,
+		GeneratedAt:   time.Now(),
+	}, nil
+}
+
+// resourceUsage summarizes a project's fleet over the trailing period from local state + the ledger
+// series. Compute/idle figures come from StateHistory (running vs. stopped hours).
+func (s *Server) resourceUsage(ctx context.Context, projectID string, period time.Duration) (*types.ProjectResourceUsage, error) {
+	now := time.Now()
+	start := now.Add(-period)
+
+	usage := &types.ProjectResourceUsage{
+		ProjectID:         projectID,
+		MeasurementPeriod: period,
+		LastUpdated:       now,
+	}
+
+	if s.stateManager == nil {
+		return usage, nil
+	}
+	st, err := s.stateManager.LoadState()
+	if err != nil {
+		return usage, nil // no state → empty usage, not an error (matches prior lenient behavior)
+	}
+
+	for _, inst := range st.Instances {
+		if inst.ProjectID != projectID {
+			continue
+		}
+		if inst.State == "terminated" || inst.State == "shutting-down" {
+			continue
+		}
+		usage.TotalInstances++
+		if inst.State == "running" {
+			usage.ActiveInstances++
+		}
+		usage.TotalStorage += inst.StorageGB
+
+		running := runningHoursInWindow(inst, start, now)
+		usage.ComputeHours += running
+		// IdleSavings: compute that WOULD have accrued had the instance run the whole period but did
+		// not (i.e. the avoided on-demand cost of the stopped time).
+		windowHours := now.Sub(start).Hours()
+		stopped := windowHours - running
+		if stopped > 0 && inst.HourlyRate > 0 {
+			usage.IdleSavings += stopped * inst.HourlyRate
+		}
+	}
+
+	return usage, nil
+}
+
+// costTrends returns the per-period spending series in the shape the CLI history table renders
+// (budget_commands.go outputHistoryTable): trends is a list of {date, spent, budget} objects. This is
+// deliberately NOT the CostDataPoint JSON shape — the pre-3c stub emitted CostDataPoint, which the CLI
+// never parsed, so the history table was always empty. period is "7d" / "30d" / "90d".
+func (s *Server) costTrends(ctx context.Context, projectID, period string) (map[string]interface{}, error) {
+	days := 30
+	switch period {
+	case "7d":
+		days = 7
+	case "90d":
+		days = 90
+	}
+	now := time.Now()
+	start := now.AddDate(0, 0, -days)
+
+	series, err := s.ledgerCostSeries(ctx, projectID, start, now)
+	if err != nil {
+		return nil, err
+	}
+
+	// Daily allocation for the budget column: MonthlyLimit/30 when set, else TotalBudget prorated over
+	// the window, else 0. Best-effort — the CLI uses it only for the usage% and bar scaling.
+	dailyBudget := s.dailyAllocation(ctx, projectID, days)
+
+	trends := make([]map[string]interface{}, 0, len(series))
+	for _, pt := range series {
+		trends = append(trends, map[string]interface{}{
+			"date":   pt.Timestamp.Format("2006-01-02"),
+			"spent":  pt.DailyCost,
+			"budget": dailyBudget,
+		})
+	}
+
+	return map[string]interface{}{
+		"project_id": projectID,
+		"period":     period,
+		"days":       days,
+		"trends":     trends,
+		"count":      len(trends),
+	}, nil
+}
+
+// dailyAllocation estimates a per-day budget figure for the trends "budget" column. MonthlyLimit
+// divided by 30 when present; otherwise the total budget spread across the requested window; 0 when
+// the project has no budget.
+func (s *Server) dailyAllocation(ctx context.Context, projectID string, days int) float64 {
+	proj, err := s.projectManager.GetProject(ctx, projectID)
+	if err != nil || proj.Budget == nil {
+		return 0
+	}
+	if proj.Budget.MonthlyLimit != nil && *proj.Budget.MonthlyLimit > 0 {
+		return *proj.Budget.MonthlyLimit / 30.0
+	}
+	if proj.Budget.TotalBudget > 0 && days > 0 {
+		return proj.Budget.TotalBudget / float64(days)
+	}
+	return 0
+}
+
+// runningHoursInWindow sums the time an instance spent in the "running" state within [start, end),
+// from its StateHistory. Mirrors spend_observer.go's runningHours but clips to an explicit window so
+// the breakdown/usage reflect only the requested period. With no history it falls back to the full
+// window if currently running, else 0.
+func runningHoursInWindow(inst types.Instance, start, end time.Time) float64 {
+	clip := func(a, b time.Time) float64 {
+		if a.Before(start) {
+			a = start
+		}
+		if b.After(end) {
+			b = end
+		}
+		if b.After(a) {
+			return b.Sub(a).Hours()
+		}
+		return 0
+	}
+
+	if len(inst.StateHistory) == 0 {
+		if inst.State == "running" {
+			base := inst.LaunchTime
+			if base.IsZero() || base.Before(start) {
+				base = start
+			}
+			return clip(base, end)
+		}
+		return 0
+	}
+
+	var hours float64
+	for i, tr := range inst.StateHistory {
+		if tr.ToState != "running" {
+			continue
+		}
+		segEnd := end
+		if i+1 < len(inst.StateHistory) {
+			segEnd = inst.StateHistory[i+1].Timestamp
+		}
+		hours += clip(tr.Timestamp, segEnd)
+	}
+	return hours
+}

--- a/pkg/daemon/cost_aggregation_test.go
+++ b/pkg/daemon/cost_aggregation_test.go
@@ -1,0 +1,282 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	be "github.com/scttfrdmn/budgetengine"
+	"github.com/scttfrdmn/prism/pkg/project"
+	"github.com/scttfrdmn/prism/pkg/seam/filestore"
+	"github.com/scttfrdmn/prism/pkg/state"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// newTestCostServer builds a Server with a file-backed project manager, spend ledger, and state
+// manager (all under temp dirs; no AWS) — enough to exercise the Phase 3d ledger aggregators.
+func newTestCostServer(t *testing.T, instances ...types.Instance) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("PRISM_STATE_DIR", dir)
+
+	pm, err := project.NewManagerWithStore(filestore.New[types.Project](dir + "/projects"))
+	if err != nil {
+		t.Fatalf("project manager: %v", err)
+	}
+	sm, err := state.NewManager()
+	if err != nil {
+		t.Fatalf("state manager: %v", err)
+	}
+	if len(instances) > 0 {
+		st, _ := sm.LoadState()
+		if st.Instances == nil {
+			st.Instances = map[string]types.Instance{}
+		}
+		for _, inst := range instances {
+			st.Instances[inst.ID] = inst
+		}
+		if err := sm.SaveState(st); err != nil {
+			t.Fatalf("save state: %v", err)
+		}
+	}
+	return &Server{
+		projectManager: pm,
+		spendLedger:    newTestSpendStore(t),
+		stateManager:   sm,
+	}
+}
+
+// seedEstimate appends an estimate SpendEvent (carrying the per-resource line-item split) at `at`.
+func seedEstimate(t *testing.T, s *Server, projectID, instanceID string, compute, storage float64, at time.Time) {
+	t.Helper()
+	ev := be.SpendEvent{
+		ID:           instanceID + ":" + at.Format(time.RFC3339Nano),
+		AllocationID: engineAllocationID,
+		Amount:       compute + storage,
+		At:           at,
+		Source:       "estimate",
+		ResourceID:   instanceID,
+		Compute:      compute,
+		Storage:      storage,
+	}
+	if err := s.spendLedger.AppendSpend(context.Background(), projectScope(projectID), ev); err != nil {
+		t.Fatalf("append estimate: %v", err)
+	}
+}
+
+func runningInst(id, name, typ, projectID string, hourly, storageGB float64, launched time.Time) types.Instance {
+	return types.Instance{
+		ID: id, Name: name, InstanceType: typ, ProjectID: projectID, State: "running",
+		HourlyRate: hourly, StorageGB: storageGB, LaunchTime: launched,
+	}
+}
+
+// TestLedgerCostSeries_DayBucketsAndCumulative: estimate events across 2 days / 2 instances produce
+// ascending day buckets with cumulative TotalCost, per-day DailyCost, and a per-instance split that
+// sums to the instance total.
+func TestLedgerCostSeries_DayBucketsAndCumulative(t *testing.T) {
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	s := newTestCostServer(t,
+		runningInst("i-1", "web", "m7i.large", "proj", 0.10, 100, launched),
+		runningInst("i-2", "db", "r7i.xlarge", "proj", 0.20, 200, launched),
+	)
+	day1 := time.Date(2026, 7, 2, 6, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 7, 3, 6, 0, 0, 0, time.UTC)
+	seedEstimate(t, s, "proj", "i-1", 10, 1, day1)
+	seedEstimate(t, s, "proj", "i-2", 20, 2, day1)
+	seedEstimate(t, s, "proj", "i-1", 5, 0.5, day2)
+
+	series, err := s.ledgerCostSeries(context.Background(), "proj",
+		time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("series: %v", err)
+	}
+	if len(series) != 2 {
+		t.Fatalf("want 2 day buckets, got %d", len(series))
+	}
+	// Day 1: 10+1+20+2 = 33; Day 2: 5+0.5 = 5.5.
+	if d := series[0].DailyCost; d < 32.99 || d > 33.01 {
+		t.Fatalf("day1 DailyCost = %.2f, want 33", d)
+	}
+	if d := series[1].DailyCost; d < 5.49 || d > 5.51 {
+		t.Fatalf("day2 DailyCost = %.2f, want 5.5", d)
+	}
+	// TotalCost is cumulative: day2 == day1 + day2 daily.
+	if tc := series[1].TotalCost; tc < 38.49 || tc > 38.51 {
+		t.Fatalf("day2 TotalCost = %.2f, want cumulative 38.5", tc)
+	}
+	if !series[0].Timestamp.Before(series[1].Timestamp) {
+		t.Fatal("series not ascending by day")
+	}
+	// Day 1 has two instance lines; each Compute+Storage == TotalCost.
+	if len(series[0].InstanceCosts) != 2 {
+		t.Fatalf("day1 want 2 instance lines, got %d", len(series[0].InstanceCosts))
+	}
+	for _, ic := range series[0].InstanceCosts {
+		if diff := ic.TotalCost - (ic.ComputeCost + ic.StorageCost); diff > 1e-9 || diff < -1e-9 {
+			t.Fatalf("%s TotalCost %.4f != Compute+Storage %.4f", ic.InstanceName, ic.TotalCost, ic.ComputeCost+ic.StorageCost)
+		}
+	}
+}
+
+// TestCostBreakdown_AggregatesWindow: the breakdown sums per-instance component costs over the window,
+// synthesizes per-instance storage lines, and names/types instances from state.
+func TestCostBreakdown_AggregatesWindow(t *testing.T) {
+	launched := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	s := newTestCostServer(t, runningInst("i-1", "web", "m7i.large", "proj", 0.10, 100, launched))
+	seedEstimate(t, s, "proj", "i-1", 10, 1, time.Date(2026, 7, 2, 6, 0, 0, 0, time.UTC))
+	seedEstimate(t, s, "proj", "i-1", 5, 0.5, time.Date(2026, 7, 3, 6, 0, 0, 0, time.UTC))
+
+	bd, err := s.costBreakdown(context.Background(), "proj",
+		time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+	if tc := bd.TotalCost; tc < 16.49 || tc > 16.51 {
+		t.Fatalf("TotalCost = %.2f, want 16.5", tc)
+	}
+	if len(bd.InstanceCosts) != 1 {
+		t.Fatalf("want 1 instance line, got %d", len(bd.InstanceCosts))
+	}
+	ic := bd.InstanceCosts[0]
+	if ic.InstanceName != "web" || ic.InstanceType != "m7i.large" {
+		t.Fatalf("instance identity = %q/%q, want web/m7i.large", ic.InstanceName, ic.InstanceType)
+	}
+	if ic.ComputeCost < 14.99 || ic.ComputeCost > 15.01 {
+		t.Fatalf("ComputeCost = %.2f, want 15", ic.ComputeCost)
+	}
+	if len(bd.StorageCosts) != 1 || bd.StorageCosts[0].VolumeName != "web-root" {
+		t.Fatalf("want 1 synthesized storage line web-root, got %+v", bd.StorageCosts)
+	}
+	if bd.StorageCosts[0].SizeGB != 100 {
+		t.Fatalf("storage SizeGB = %.0f, want 100", bd.StorageCosts[0].SizeGB)
+	}
+}
+
+// TestResourceUsage_CountsAndCompute: usage reflects active/total counts, storage, and compute hours.
+func TestResourceUsage_CountsAndCompute(t *testing.T) {
+	launched := time.Now().Add(-48 * time.Hour)
+	running := runningInst("i-1", "web", "m7i.large", "proj", 0.10, 100, launched)
+	stopped := runningInst("i-2", "db", "r7i.xlarge", "proj", 0.20, 200, launched)
+	stopped.State = "stopped"
+	other := runningInst("i-3", "x", "m7i.large", "other-proj", 0.10, 50, launched)
+	s := newTestCostServer(t, running, stopped, other)
+
+	usage, err := s.resourceUsage(context.Background(), "proj", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("usage: %v", err)
+	}
+	if usage.TotalInstances != 2 {
+		t.Fatalf("TotalInstances = %d, want 2 (other-proj excluded)", usage.TotalInstances)
+	}
+	if usage.ActiveInstances != 1 {
+		t.Fatalf("ActiveInstances = %d, want 1", usage.ActiveInstances)
+	}
+	if usage.TotalStorage != 300 {
+		t.Fatalf("TotalStorage = %.0f, want 300", usage.TotalStorage)
+	}
+	// Running instance (no StateHistory) accrues ~24h of compute over the 24h window; stopped accrues 0.
+	if usage.ComputeHours < 23.9 || usage.ComputeHours > 24.1 {
+		t.Fatalf("ComputeHours = %.2f, want ~24", usage.ComputeHours)
+	}
+}
+
+// TestCostTrends_CLIShape: trends elements carry exactly date/spent/budget, and days/count match.
+func TestCostTrends_CLIShape(t *testing.T) {
+	launched := time.Now().Add(-72 * time.Hour)
+	s := newTestCostServer(t, runningInst("i-1", "web", "m7i.large", "proj", 0.10, 100, launched))
+	// Give the project a budget so the "budget" column is non-zero.
+	ml := 300.0
+	if err := s.projectManager.SetProjectBudget(context.Background(), mustProject(t, s, "proj"),
+		&types.ProjectBudget{TotalBudget: 300, MonthlyLimit: &ml, BudgetPeriod: types.BudgetPeriodMonthly}); err != nil {
+		t.Fatalf("set budget: %v", err)
+	}
+	seedEstimate(t, s, mustProject(t, s, "proj"), "i-1", 10, 1, time.Now().Add(-24*time.Hour))
+
+	trends, err := s.costTrends(context.Background(), mustProject(t, s, "proj"), "7d")
+	if err != nil {
+		t.Fatalf("trends: %v", err)
+	}
+	if trends["days"] != 7 {
+		t.Fatalf("days = %v, want 7", trends["days"])
+	}
+	list, _ := trends["trends"].([]map[string]interface{})
+	if len(list) != 1 {
+		t.Fatalf("want 1 trend element, got %d", len(list))
+	}
+	// Round-trip through JSON to assert the exact wire keys the CLI reads.
+	raw, _ := json.Marshal(list[0])
+	var elem map[string]interface{}
+	_ = json.Unmarshal(raw, &elem)
+	for _, k := range []string{"date", "spent", "budget"} {
+		if _, ok := elem[k]; !ok {
+			t.Fatalf("trend element missing key %q; got %v", k, elem)
+		}
+	}
+	if elem["spent"].(float64) < 10.9 || elem["spent"].(float64) > 11.1 {
+		t.Fatalf("spent = %v, want ~11", elem["spent"])
+	}
+}
+
+// mustProject creates a project named after the given ID marker and returns its real ID; a small
+// helper so seed calls read naturally. It caches nothing — callers pass the returned ID.
+func mustProject(t *testing.T, s *Server, marker string) string {
+	t.Helper()
+	// Reuse an existing project with this marker name if present (idempotent within a test).
+	projects, _ := s.projectManager.ListProjects(context.Background(), nil)
+	for _, p := range projects {
+		if p.Name == marker {
+			return p.ID
+		}
+	}
+	p, err := s.projectManager.CreateProject(context.Background(), &project.CreateProjectRequest{
+		Name: marker, Owner: "tester@example.com",
+	})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	return p.ID
+}
+
+// TestLedgerCostSeries_TerminatedInstanceFallback: an event whose instance is gone from state falls
+// back to the raw ResourceID for a name and "unknown" for the type.
+func TestLedgerCostSeries_TerminatedInstanceFallback(t *testing.T) {
+	s := newTestCostServer(t) // no instances in state
+	seedEstimate(t, s, "proj", "i-ghost", 7, 0, time.Date(2026, 7, 2, 6, 0, 0, 0, time.UTC))
+
+	series, err := s.ledgerCostSeries(context.Background(), "proj",
+		time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	if err != nil || len(series) != 1 {
+		t.Fatalf("series err=%v len=%d, want 1", err, len(series))
+	}
+	ic := series[0].InstanceCosts[0]
+	if ic.InstanceName != "i-ghost" || ic.InstanceType != "unknown" {
+		t.Fatalf("fallback identity = %q/%q, want i-ghost/unknown", ic.InstanceName, ic.InstanceType)
+	}
+}
+
+// TestLedgerCostSeries_BilledFoldsIntoProjectTotal: billed / billed-reversal events (no ResourceID)
+// affect the day's DailyCost but produce no per-instance line.
+func TestLedgerCostSeries_BilledFoldsIntoProjectTotal(t *testing.T) {
+	s := newTestCostServer(t, runningInst("i-1", "web", "m7i.large", "proj", 0.10, 100, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)))
+	day := time.Date(2026, 7, 2, 6, 0, 0, 0, time.UTC)
+	seedEstimate(t, s, "proj", "i-1", 10, 0, day)
+	// Reconciliation: reverse the estimate, add a billed figure — neither carries ResourceID.
+	ctx := context.Background()
+	_ = s.spendLedger.AppendSpend(ctx, projectScope("proj"), be.SpendEvent{ID: "rev", AllocationID: engineAllocationID, Amount: -10, At: day.Add(time.Hour), Source: "billed-reversal"})
+	_ = s.spendLedger.AppendSpend(ctx, projectScope("proj"), be.SpendEvent{ID: "bill", AllocationID: engineAllocationID, Amount: 8, At: day.Add(time.Hour), Source: "billed"})
+
+	series, err := s.ledgerCostSeries(ctx, "proj",
+		time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC))
+	if err != nil || len(series) != 1 {
+		t.Fatalf("series err=%v len=%d, want 1", err, len(series))
+	}
+	// DailyCost nets to 10 - 10 + 8 = 8; the per-instance line reflects only the $10 estimate.
+	if d := series[0].DailyCost; d < 7.99 || d > 8.01 {
+		t.Fatalf("DailyCost = %.2f, want 8 (billed nets over estimate)", d)
+	}
+	if len(series[0].InstanceCosts) != 1 || series[0].InstanceCosts[0].ComputeCost < 9.99 {
+		t.Fatalf("per-instance line should reflect the $10 estimate only, got %+v", series[0].InstanceCosts)
+	}
+}

--- a/pkg/daemon/cost_handlers.go
+++ b/pkg/daemon/cost_handlers.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/scttfrdmn/prism/pkg/cost"
-	"github.com/scttfrdmn/prism/pkg/project"
 	"github.com/scttfrdmn/prism/pkg/types"
 )
 
@@ -209,21 +208,12 @@ func (s *Server) handleGetCostTrends(w http.ResponseWriter, r *http.Request) {
 		period = "30d"
 	}
 
-	// Phase 3c (#653): the BudgetTracker cost-history store is retired; ledger-derived trends land in
-	// Phase 3d (#654). Preserve the response shape with an empty series until then.
-	days := 30
-	switch period {
-	case "7d":
-		days = 7
-	case "90d":
-		days = 90
-	}
-	trends := map[string]interface{}{
-		"project_id": projectID,
-		"period":     period,
-		"days":       days,
-		"trends":     []project.CostDataPoint{},
-		"count":      0,
+	// Phase 3d (#654): ledger-derived daily trends, in the {date,spent,budget} shape the CLI history
+	// table renders (see costTrends).
+	trends, err := s.costTrends(context.Background(), projectID, period)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/daemon/project_handlers.go
+++ b/pkg/daemon/project_handlers.go
@@ -524,10 +524,16 @@ func (s *Server) handleProjectBudgetHistory(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	// Phase 3c (#653): the BudgetTracker cost-history store is retired. Ledger-derived history lands in
-	// Phase 3d (#654); until then this endpoint returns an empty series (its prior prod shape — the
-	// tracker never accumulated history in production).
-	history := []project.CostDataPoint{}
+	// Phase 3d (#654): daily cost history is the ledger-derived series over the trailing window.
+	now := time.Now()
+	history, err := s.ledgerCostSeries(context.Background(), projectID, now.AddDate(0, 0, -days), now)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to get cost history: %v", err))
+		return
+	}
+	if history == nil {
+		history = []project.CostDataPoint{}
+	}
 
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"project_id": projectID,
@@ -573,7 +579,7 @@ func (s *Server) handleProjectCosts(w http.ResponseWriter, r *http.Request, proj
 	}
 
 	ctx := context.Background()
-	costBreakdown, err := s.projectManager.GetProjectCostBreakdown(ctx, projectID, startDate, endDate)
+	costBreakdown, err := s.costBreakdown(ctx, projectID, startDate, endDate)
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to get cost breakdown: %v", err))
 		return
@@ -599,7 +605,7 @@ func (s *Server) handleProjectUsage(w http.ResponseWriter, r *http.Request, proj
 	}
 
 	ctx := context.Background()
-	usage, err := s.projectManager.GetProjectResourceUsage(ctx, projectID, period)
+	usage, err := s.resourceUsage(ctx, projectID, period)
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to get resource usage: %v", err))
 		return
@@ -1446,15 +1452,24 @@ func (s *Server) handleProjectMonthlyReport(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Retrieve project and cost history
-	proj, err := s.projectManager.GetProject(context.Background(), projectID)
+	ctx := context.Background()
+	proj, err := s.projectManager.GetProject(ctx, projectID)
 	if err != nil {
 		s.writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
 
-	// Phase 3c (#653): tracker cost history retired; ledger-derived history is Phase 3d (#654). The
-	// monthly report renders from budget + (empty) history until then.
+	// Phase 3d (#654): feed GenerateMonthlyReport the real ledger-derived series for the target month.
+	// GenerateMonthlyReport re-clips to the month itself, but scoping the query keeps it cheap.
 	var history []project.CostDataPoint
+	if mt, perr := time.Parse("2006-01", month); perr == nil {
+		monthStart := time.Date(mt.Year(), mt.Month(), 1, 0, 0, 0, 0, time.UTC)
+		monthEnd := monthStart.AddDate(0, 1, 0)
+		if history, err = s.ledgerCostSeries(ctx, projectID, monthStart, monthEnd); err != nil {
+			s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to build cost history: %v", err))
+			return
+		}
+	}
 
 	report, err := project.GenerateMonthlyReport(projectID, month, history, proj.Budget)
 	if err != nil {

--- a/pkg/project/manager.go
+++ b/pkg/project/manager.go
@@ -436,35 +436,9 @@ func (m *Manager) UpdateProjectMember(ctx context.Context, projectID, userID str
 	return m.saveProjects()
 }
 
-// GetProjectCostBreakdown retrieves detailed cost analysis for a project
-func (m *Manager) GetProjectCostBreakdown(ctx context.Context, projectID string, startDate, endDate time.Time) (*types.ProjectCostBreakdown, error) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-
-	_, exists := m.projects[projectID]
-	if !exists {
-		return nil, fmt.Errorf("project %q not found", projectID)
-	}
-
-	// Cost breakdown is derived from the budgetengine spend ledger in the daemon layer (#654,
-	// Phase 3d). The project Manager no longer owns cost analytics; return an empty breakdown for
-	// the DTO shape until the daemon-side ledger aggregation lands.
-	return &types.ProjectCostBreakdown{ProjectID: projectID}, nil
-}
-
-// GetProjectResourceUsage retrieves resource utilization metrics for a project.
-func (m *Manager) GetProjectResourceUsage(ctx context.Context, projectID string, period time.Duration) (*types.ProjectResourceUsage, error) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-
-	_, exists := m.projects[projectID]
-	if !exists {
-		return nil, fmt.Errorf("project %q not found", projectID)
-	}
-
-	// Resource usage is a daemon-layer, ledger-derived concern (#654, Phase 3d); empty for now.
-	return &types.ProjectResourceUsage{ProjectID: projectID}, nil
-}
+// Cost breakdown and resource usage are derived from the budgetengine spend ledger in the daemon
+// layer (Phase 3d, #654) — see pkg/daemon/cost_aggregation.go. The project Manager owns identity and
+// lifecycle only, and deliberately stays ledger-free.
 
 // loadProjects loads all project records from the seam into the in-memory map.
 func (m *Manager) loadProjects() error {

--- a/pkg/project/manager_test.go
+++ b/pkg/project/manager_test.go
@@ -2117,52 +2117,9 @@ func TestRequestValidation_TransferProjectRequest(t *testing.T) {
 	}
 }
 
-// TestManager_GetProjectCostBreakdown tests cost breakdown retrieval
-func TestManager_GetProjectCostBreakdown(t *testing.T) {
-	manager := setupTestManager(t)
-	ctx := context.Background()
-
-	// Test with non-existent project
-	_, err := manager.GetProjectCostBreakdown(ctx, "non-existent", time.Now().Add(-24*time.Hour), time.Now())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
-
-	// Test with existing project (may fail if budget tracker not initialized, but covers the function)
-	project, err := manager.CreateProject(ctx, &CreateProjectRequest{
-		Name:        "Cost Test Project",
-		Description: "For cost breakdown testing",
-		Owner:       "test-user",
-	})
-	require.NoError(t, err)
-
-	// This may return an error if budget tracker isn't fully initialized, but it exercises the code path
-	_, _ = manager.GetProjectCostBreakdown(ctx, project.ID, time.Now().Add(-24*time.Hour), time.Now())
-}
-
-// TestManager_GetProjectResourceUsage tests resource usage retrieval
-func TestManager_GetProjectResourceUsage(t *testing.T) {
-	manager := setupTestManager(t)
-	ctx := context.Background()
-
-	// Test with non-existent project
-	_, err := manager.GetProjectResourceUsage(ctx, "non-existent", 24*time.Hour)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
-
-	// Test with existing project
-	project, err := manager.CreateProject(ctx, &CreateProjectRequest{
-		Name:        "Resource Test Project",
-		Description: "For resource usage testing",
-		Owner:       "test-user",
-	})
-	require.NoError(t, err)
-
-	// This may return an error if budget tracker isn't fully initialized, but it exercises the code path
-	_, _ = manager.GetProjectResourceUsage(ctx, project.ID, 24*time.Hour)
-}
-
-// Budget status derivation moved to the daemon layer (Phase 3c, #653); see
-// pkg/daemon/budget_status_test.go. Manager no longer owns budget status.
+// Cost breakdown and resource usage moved to the daemon layer (Phase 3d, #654); see
+// pkg/daemon/cost_aggregation_test.go. Budget status likewise (Phase 3c, #653); see
+// pkg/daemon/budget_status_test.go. The Manager no longer owns any cost/budget analytics.
 
 // ============ v0.12.0 Tests ============
 


### PR DESCRIPTION
## Phase 3d (#654) — cost analytics on real ledger data

Re-implements the four cost-analytics surfaces that returned **zeros** after Phase 3c, aggregating the `budgetengine` spend ledger in a new `pkg/daemon/cost_aggregation.go`. Everything derives from one primitive.

### `ledgerCostSeries` — the fold
Day-bucketed fold over the project's events (`s.spendLedger.Spend(projectScope(id))`):
- `estimate` events carry `ResourceID` + un-blended `Compute`/`Storage` (#652) → attribute per-instance per-day.
- `billed`/`billed-reversal` reconciliation events have **no** `ResourceID` → fold into the day's project total only (documented — per-instance attribution of billed corrections is a future enrichment).
- Each `CostDataPoint`: `TotalCost` = running **cumulative** (the burn-rate/history helpers difference it between points), `DailyCost` = that day's spend.

### The four surfaces (no signature changes, wire shapes preserved)
- **`GET /projects/{id}/costs`** → populated `ProjectCostBreakdown`: per-instance compute/storage, running/stopped hours from `StateHistory` clipped to the window, synthesized per-instance root-volume `StorageCost` lines.
- **`GET /projects/{id}/usage`** → real `ProjectResourceUsage`: active/total counts, total storage, compute hours, idle savings (avoided compute on stopped time).
- **`GET /cost/trends`** → emits `{date, spent, budget}` — **the shape the CLI history table actually renders**. The pre-3c stub emitted `CostDataPoint` (`timestamp`/`total_cost`), which `outputHistoryTable` never parsed, so `prism budget history` was always blank. This fixes that latent bug.
- **monthly report** + **budget history** endpoints now feed the real series into the existing `GenerateMonthlyReport`.
- **`BudgetStatus.BurnRate`** is now populated (via the existing `BurnRateCalculator` — the same analytics the retired tracker fed). `Surplus` stays nil pending banking/rollover (Phase 3e, #655).

### Cleanup
Removes the now-dead `Manager.GetProjectCostBreakdown`/`GetProjectResourceUsage` stubs + their unit tests — the daemon owns cost aggregation, keeping `pkg/project` ledger-free (consistent with 3c).

### Verification
- `go build`/`vet`/`gofmt`/`goimports`/`gocyclo`/`golangci-lint`/`govulncheck` clean; `go test ./...` green.
- New `cost_aggregation_test.go`: series (ascending day buckets, cumulative total, per-instance Compute+Storage==Total), breakdown window aggregation + synthesized storage, resource usage counts/compute, trends CLI `{date,spent,budget}` shape, terminated-instance → `unknown` fallback, billed-events-fold-into-project-total-not-per-instance.

### Out of scope
- GUI `/costs` flat shape (`ec2_compute`/`ebs_storage`/…): the Go endpoint has never emitted these (GUI zero-fills); reconciling it is a separate frontend task.
- `Surplus`/banking + forecast (3e #655); spot pricing (#659); ActionSink enforcement (#656).

Closes #654