### PR TITLE
feat(budget): live budget enforcement / auto-actions on the ledger (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Live budget enforcement — auto-actions fire again (#656).** Per-project budget auto-actions
+  (`AutoActions[]`: threshold %% → hibernate/stop/prevent-launch/notify) and the safety cushion
+  (headroom → one action) are evaluated against the `budgetengine` spend ledger on the daemon's
+  monitoring tick and executed when breached — restoring behavior that went dead when the legacy
+  BudgetTracker was retired. A new daemon `budgetEnforcer` (`pkg/daemon/budget_enforcer.go`) folds each
+  budgeted project's ledger via the same `budgetStatus` the API returns, so enforcement and the status
+  readout agree; it drives the existing `Server.ExecuteHibernateAll/StopAll/PreventLaunch` executors
+  and the surviving `CushionEvaluator`, and sends notifications through the alert dispatcher
+  (Slack webhook when `PRISM_SLACK_WEBHOOK` is set, else log). **Off by default** — destructive actions
+  require an explicit opt-in via `budget_enforcement_enabled` (or `PRISM_BUDGET_ENFORCEMENT=true`);
+  the evaluation cadence is `budget_enforcement_interval_minutes` (default 10, 1-minute floor).
+  Dedup is fire-once-per-budget-period via `LastTriggered` timestamps (persisted on each action and the
+  cushion), so a breach acts once per month rather than every tick.
+
 ### Changed
 - **Spend estimate uses the real spot price for spot instances (#659).** The spend observer's compute
   estimate previously used `Instance.HourlyRate` (on-demand list price) for every instance, badly

--- a/pkg/daemon/budget_enforcer.go
+++ b/pkg/daemon/budget_enforcer.go
@@ -1,0 +1,189 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/scttfrdmn/prism/pkg/alerting"
+	"github.com/scttfrdmn/prism/pkg/project"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// Live budget enforcement (#656). The per-project auto-actions (ProjectBudget.AutoActions — threshold
+// %% → hibernate/stop/prevent-launch/notify) and the cushion (ProjectBudget.Cushion — headroom → one
+// mode) are persisted config, but nothing evaluated them after the BudgetTracker was retired (its
+// checkBudgetAlerts loop went with it). This enforcer restores that loop, now folding the budgetengine
+// spend ledger (via Server.budgetStatus) so enforcement and the status readout agree.
+//
+// It runs on the StateMonitor tick (alongside the spend observer), self-throttled to its own interval.
+// OFF by default (config.BudgetEnforcementEnabled) because it takes destructive actions; dedup is
+// fire-once-per-budget-period via the LastTriggered timestamps on each action / the cushion, so a
+// breach fires once per month (or once per project-lifetime window) rather than every tick.
+
+// enforcerStatusFn folds a project's ledger into a BudgetStatus (Server.budgetStatus). Injected so the
+// enforcer is unit-testable without a live daemon.
+type enforcerStatusFn func(ctx context.Context, projectID string) (*project.BudgetStatus, error)
+
+// budgetEnforcer evaluates budgets and fires auto-actions. It depends only on small injected
+// collaborators (executor, status fn, project list/save), never AWS directly.
+type budgetEnforcer struct {
+	enabled  bool
+	interval time.Duration
+	clock    func() time.Time
+
+	executor    project.ActionExecutor           // hibernate/stop/prevent-launch (Server implements it)
+	cushionEval *project.CushionEvaluator        // headroom-mode evaluator (wraps executor + alerter)
+	alerter     alerting.AlertDispatcher         // budget/auto-action notifications
+	status      enforcerStatusFn                 // ledger-derived per-project BudgetStatus
+	listBudgets func() ([]*types.Project, error) // projects to evaluate (filtered to Budget != nil)
+	saveBudget  func(ctx context.Context, projectID string, b *types.ProjectBudget) error
+
+	lastRun time.Time // throttle
+}
+
+// newBudgetEnforcer builds the enforcer from the Server's collaborators. The alerter is a webhook
+// dispatcher when PRISM_SLACK_WEBHOOK is set (reviving the retired tracker's selection), else a log
+// dispatcher. The Server itself is the ActionExecutor (ExecuteHibernateAll/StopAll/PreventLaunch).
+func (s *Server) newBudgetEnforcer(config *Config) *budgetEnforcer {
+	alerter := budgetAlerter()
+	return &budgetEnforcer{
+		enabled:     config.BudgetEnforcementEnabled,
+		interval:    config.GetBudgetEnforcementInterval(),
+		clock:       time.Now,
+		executor:    s,
+		cushionEval: project.NewCushionEvaluator(s, alerter),
+		alerter:     alerter,
+		status:      s.budgetStatus,
+		listBudgets: func() ([]*types.Project, error) {
+			return s.projectManager.ListProjects(context.Background(), nil)
+		},
+		saveBudget: func(ctx context.Context, projectID string, b *types.ProjectBudget) error {
+			return s.projectManager.SetProjectBudget(ctx, projectID, b)
+		},
+	}
+}
+
+// budgetAlerter selects the notification backend: a Slack webhook dispatcher when PRISM_SLACK_WEBHOOK
+// is configured, otherwise the default log dispatcher.
+func budgetAlerter() alerting.AlertDispatcher {
+	if url := os.Getenv("PRISM_SLACK_WEBHOOK"); url != "" {
+		return alerting.NewWebhookDispatcher(alerting.WebhookConfig{
+			Channels: []alerting.Channel{{Type: alerting.ChannelSlack, Target: url}},
+		})
+	}
+	return alerting.NewLogDispatcher()
+}
+
+// Enforce runs one enforcement pass over all budgeted projects, if enabled and the throttle interval
+// has elapsed. Errors on a single project are logged and skipped (fail-open) so one bad project never
+// stalls the loop.
+func (e *budgetEnforcer) Enforce(ctx context.Context) {
+	if e == nil || !e.enabled || e.status == nil || e.listBudgets == nil {
+		return
+	}
+	now := e.clock()
+	if !e.lastRun.IsZero() && now.Sub(e.lastRun) < e.interval {
+		return // throttled
+	}
+	e.lastRun = now
+
+	projects, err := e.listBudgets()
+	if err != nil {
+		return
+	}
+	for _, proj := range projects {
+		if proj.Budget == nil {
+			continue
+		}
+		e.enforceProject(ctx, proj, now)
+	}
+}
+
+// enforceProject evaluates one project's budget against the ledger and fires any due actions. It
+// mutates the project's budget copy (LastTriggered stamps) and persists only when something fired.
+func (e *budgetEnforcer) enforceProject(ctx context.Context, proj *types.Project, now time.Time) {
+	status, err := e.status(ctx, proj.ID)
+	if err != nil || status == nil || !status.BudgetEnabled {
+		return
+	}
+	budget := proj.Budget
+	dirty := false
+
+	// Threshold-based auto-actions: fire when spent%% has reached the action's threshold and it hasn't
+	// already fired this budget period.
+	for i := range budget.AutoActions {
+		action := &budget.AutoActions[i]
+		if !action.Enabled || status.SpentPercentage < action.Threshold {
+			continue
+		}
+		if firedThisPeriod(action.LastTriggered, now, budget) {
+			continue
+		}
+		e.fireAutoAction(ctx, proj, *action, status)
+		action.LastTriggered = ptrTime(now)
+		dirty = true
+	}
+
+	// Cushion: fire when remaining budget is at/below the configured headroom.
+	if budget.Cushion != nil && budget.Cushion.Enabled && !firedThisPeriod(budget.Cushion.LastTriggeredAt, now, budget) {
+		cfg := toCushionConfig(budget.Cushion)
+		if e.cushionEval.Evaluate(status, cfg).Triggered {
+			_ = e.cushionEval.Execute(ctx, proj.ID, proj.Name, cfg, *status)
+			budget.Cushion.LastTriggeredAt = ptrTime(now)
+			dirty = true
+		}
+	}
+
+	if dirty && e.saveBudget != nil {
+		_ = e.saveBudget(ctx, proj.ID, budget)
+	}
+}
+
+// fireAutoAction dispatches a single auto-action's effect (via the executor) and sends a notification.
+// notify-only actions send an alert without touching instances.
+func (e *budgetEnforcer) fireAutoAction(ctx context.Context, proj *types.Project, action types.BudgetAutoAction, status *project.BudgetStatus) {
+	if e.alerter != nil {
+		alert := alerting.FormatAutoActionAlert(proj.ID, proj.Name, action.Action, status.SpentAmount, status.TotalBudget)
+		_ = e.alerter.Send(ctx, alert)
+	}
+	if e.executor == nil {
+		return
+	}
+	switch action.Action {
+	case types.BudgetActionHibernateAll:
+		_ = e.executor.ExecuteHibernateAll(proj.ID)
+	case types.BudgetActionStopAll:
+		_ = e.executor.ExecuteStopAll(proj.ID)
+	case types.BudgetActionPreventLaunch:
+		_ = e.executor.ExecutePreventLaunch(proj.ID)
+	case types.BudgetActionNotifyOnly:
+		// alert already sent above
+	}
+}
+
+// firedThisPeriod reports whether a LastTriggered timestamp falls within the current budget period, so
+// an action fires at most once per period. Reuses budgetWindow (the same window the engine paces over)
+// so a monthly budget re-arms each month and a project-lifetime budget re-arms per its rolling window.
+func firedThisPeriod(last *time.Time, now time.Time, budget *types.ProjectBudget) bool {
+	if last == nil {
+		return false
+	}
+	win := budgetWindow(budget, now)
+	return !last.Before(win.Start)
+}
+
+// toCushionConfig maps the persisted types.CushionBudgetConfig onto the project.CushionConfig the
+// CushionEvaluator consumes (the mapping the retired tracker did).
+func toCushionConfig(c *types.CushionBudgetConfig) project.CushionConfig {
+	return project.CushionConfig{
+		Enabled:            c.Enabled,
+		HeadroomPercent:    c.HeadroomPercent,
+		HeadroomFixed:      c.HeadroomFixed,
+		Mode:               project.CushionMode(c.Mode),
+		NotifyBeforeAction: c.NotifyBeforeAction,
+		WarnLeadHours:      c.WarnLeadHours,
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/pkg/daemon/budget_enforcer_test.go
+++ b/pkg/daemon/budget_enforcer_test.go
@@ -1,0 +1,217 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/prism/pkg/alerting"
+	"github.com/scttfrdmn/prism/pkg/project"
+	"github.com/scttfrdmn/prism/pkg/seam/filestore"
+	"github.com/scttfrdmn/prism/pkg/types"
+)
+
+// stubExecutor records which enforcement actions were invoked, per project.
+type stubExecutor struct {
+	hibernate []string
+	stop      []string
+	prevent   []string
+}
+
+func (s *stubExecutor) ExecuteHibernateAll(projectID string) error {
+	s.hibernate = append(s.hibernate, projectID)
+	return nil
+}
+func (s *stubExecutor) ExecuteStopAll(projectID string) error {
+	s.stop = append(s.stop, projectID)
+	return nil
+}
+func (s *stubExecutor) ExecutePreventLaunch(projectID string) error {
+	s.prevent = append(s.prevent, projectID)
+	return nil
+}
+
+// captureAlerter records sent alerts.
+type captureAlerter struct{ sent []alerting.Alert }
+
+func (c *captureAlerter) Send(_ context.Context, a alerting.Alert) error {
+	c.sent = append(c.sent, a)
+	return nil
+}
+func (c *captureAlerter) SendBatch(_ context.Context, a []alerting.Alert) error {
+	c.sent = append(c.sent, a...)
+	return nil
+}
+func (c *captureAlerter) History(int) []alerting.SentAlert { return nil }
+
+// newEnforcerHarness builds a budgetEnforcer over an in-memory project manager with the given project,
+// a stub executor, a capturing alerter, and a status fn returning the supplied status.
+func newEnforcerHarness(t *testing.T, proj *types.Project, status *project.BudgetStatus) (*budgetEnforcer, *stubExecutor, *captureAlerter) {
+	t.Helper()
+	dir := t.TempDir()
+	pm, err := project.NewManagerWithStore(filestore.New[types.Project](dir + "/projects"))
+	if err != nil {
+		t.Fatalf("project manager: %v", err)
+	}
+	exec := &stubExecutor{}
+	alerter := &captureAlerter{}
+	enf := &budgetEnforcer{
+		enabled:     true,
+		interval:    time.Minute,
+		clock:       func() time.Time { return status.LastUpdated },
+		executor:    exec,
+		cushionEval: project.NewCushionEvaluator(exec, alerter),
+		alerter:     alerter,
+		status:      func(_ context.Context, _ string) (*project.BudgetStatus, error) { return status, nil },
+		listBudgets: func() ([]*types.Project, error) { return []*types.Project{proj}, nil },
+		saveBudget: func(ctx context.Context, id string, b *types.ProjectBudget) error {
+			return pm.SetProjectBudget(ctx, id, b)
+		},
+	}
+	return enf, exec, alerter
+}
+
+func monthlyBudgetProject(spentPct float64, actions []types.BudgetAutoAction, cushion *types.CushionBudgetConfig) (*types.Project, *project.BudgetStatus) {
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	total := 1000.0
+	proj := &types.Project{
+		ID:   "proj-1",
+		Name: "Test",
+		Budget: &types.ProjectBudget{
+			TotalBudget:  total,
+			BudgetPeriod: types.BudgetPeriodMonthly,
+			StartDate:    time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			AutoActions:  actions,
+			Cushion:      cushion,
+		},
+	}
+	status := &project.BudgetStatus{
+		ProjectID:       "proj-1",
+		BudgetEnabled:   true,
+		TotalBudget:     total,
+		SpentAmount:     total * spentPct,
+		RemainingBudget: total * (1 - spentPct),
+		SpentPercentage: spentPct,
+		LastUpdated:     now,
+	}
+	return proj, status
+}
+
+// TestEnforcer_AutoActionFires: an enabled hibernate action at/above its threshold fires once, sends
+// an alert, and stamps LastTriggered.
+func TestEnforcer_AutoActionFires(t *testing.T) {
+	proj, status := monthlyBudgetProject(0.90, []types.BudgetAutoAction{
+		{Threshold: 0.80, Action: types.BudgetActionHibernateAll, Enabled: true},
+	}, nil)
+	enf, exec, alerter := newEnforcerHarness(t, proj, status)
+
+	enf.Enforce(context.Background())
+
+	if len(exec.hibernate) != 1 || exec.hibernate[0] != "proj-1" {
+		t.Fatalf("hibernate calls = %v, want [proj-1]", exec.hibernate)
+	}
+	if len(alerter.sent) != 1 {
+		t.Fatalf("alerts sent = %d, want 1", len(alerter.sent))
+	}
+	if proj.Budget.AutoActions[0].LastTriggered == nil {
+		t.Fatal("LastTriggered should be set after firing")
+	}
+}
+
+// TestEnforcer_DedupWithinPeriod: a second pass in the same budget period does not re-fire; advancing
+// the clock into the next period re-arms it.
+func TestEnforcer_DedupWithinPeriod(t *testing.T) {
+	proj, status := monthlyBudgetProject(0.90, []types.BudgetAutoAction{
+		{Threshold: 0.80, Action: types.BudgetActionHibernateAll, Enabled: true},
+	}, nil)
+	enf, exec, _ := newEnforcerHarness(t, proj, status)
+
+	enf.Enforce(context.Background())
+	// Second pass, same period — advance the clock past the throttle but stay in July.
+	status.LastUpdated = status.LastUpdated.Add(2 * time.Minute)
+	enf.Enforce(context.Background())
+	if len(exec.hibernate) != 1 {
+		t.Fatalf("hibernate calls = %d, want 1 (deduped within period)", len(exec.hibernate))
+	}
+
+	// Advance into the next month → re-armed.
+	status.LastUpdated = time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	enf.Enforce(context.Background())
+	if len(exec.hibernate) != 2 {
+		t.Fatalf("hibernate calls = %d, want 2 (re-armed next period)", len(exec.hibernate))
+	}
+}
+
+// TestEnforcer_NotifyOnlyNoExecutor: a notify-only action sends an alert but calls no executor method.
+func TestEnforcer_NotifyOnlyNoExecutor(t *testing.T) {
+	proj, status := monthlyBudgetProject(0.95, []types.BudgetAutoAction{
+		{Threshold: 0.90, Action: types.BudgetActionNotifyOnly, Enabled: true},
+	}, nil)
+	enf, exec, alerter := newEnforcerHarness(t, proj, status)
+
+	enf.Enforce(context.Background())
+	if len(exec.hibernate)+len(exec.stop)+len(exec.prevent) != 0 {
+		t.Fatal("notify-only must not call any executor method")
+	}
+	if len(alerter.sent) != 1 {
+		t.Fatalf("alerts sent = %d, want 1", len(alerter.sent))
+	}
+}
+
+// TestEnforcer_CushionTriggers: a cushion whose headroom is breached fires its mode (prevent-launch)
+// and stamps Cushion.LastTriggeredAt.
+func TestEnforcer_CushionTriggers(t *testing.T) {
+	// 95%% spent → $50 remaining; headroom 10%% of $1000 = $100 → remaining <= headroom → triggered.
+	proj, status := monthlyBudgetProject(0.95, nil, &types.CushionBudgetConfig{
+		Enabled: true, HeadroomPercent: 0.10, Mode: string(project.CushionModePreventLaunch),
+	})
+	enf, exec, _ := newEnforcerHarness(t, proj, status)
+
+	enf.Enforce(context.Background())
+	if len(exec.prevent) != 1 {
+		t.Fatalf("prevent-launch calls = %d, want 1 (cushion breached)", len(exec.prevent))
+	}
+	if proj.Budget.Cushion.LastTriggeredAt == nil {
+		t.Fatal("Cushion.LastTriggeredAt should be set after firing")
+	}
+}
+
+// TestEnforcer_DisabledNoOp: with enabled=false nothing fires regardless of config.
+func TestEnforcer_DisabledNoOp(t *testing.T) {
+	proj, status := monthlyBudgetProject(0.99, []types.BudgetAutoAction{
+		{Threshold: 0.50, Action: types.BudgetActionStopAll, Enabled: true},
+	}, nil)
+	enf, exec, alerter := newEnforcerHarness(t, proj, status)
+	enf.enabled = false
+
+	enf.Enforce(context.Background())
+	if len(exec.stop) != 0 || len(alerter.sent) != 0 {
+		t.Fatal("disabled enforcer must be a no-op")
+	}
+}
+
+// TestEnforcer_BelowThreshold: spend under the action threshold does not fire.
+func TestEnforcer_BelowThreshold(t *testing.T) {
+	proj, status := monthlyBudgetProject(0.40, []types.BudgetAutoAction{
+		{Threshold: 0.80, Action: types.BudgetActionHibernateAll, Enabled: true},
+	}, nil)
+	enf, exec, _ := newEnforcerHarness(t, proj, status)
+
+	enf.Enforce(context.Background())
+	if len(exec.hibernate) != 0 {
+		t.Fatalf("hibernate calls = %d, want 0 (below threshold)", len(exec.hibernate))
+	}
+}
+
+// TestEnforcer_DisabledActionSkipped: an action with Enabled=false does not fire even over threshold.
+func TestEnforcer_DisabledActionSkipped(t *testing.T) {
+	proj, status := monthlyBudgetProject(0.90, []types.BudgetAutoAction{
+		{Threshold: 0.80, Action: types.BudgetActionHibernateAll, Enabled: false},
+	}, nil)
+	enf, exec, _ := newEnforcerHarness(t, proj, status)
+
+	enf.Enforce(context.Background())
+	if len(exec.hibernate) != 0 {
+		t.Fatalf("hibernate calls = %d, want 0 (action disabled)", len(exec.hibernate))
+	}
+}

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -25,6 +25,13 @@ type Config struct {
 	// instance), are rate-limited, and lag ~a day.
 	CostReconciliationEnabled         bool `json:"cost_reconciliation_enabled"`          // opt-in; default false
 	CostReconciliationIntervalMinutes int  `json:"cost_reconciliation_interval_minutes"` // default 1440 (24h); floored at 60
+
+	// Live budget enforcement (#656). When enabled, the daemon evaluates each project's budget against
+	// the spend ledger on a throttled tick and fires its configured auto-actions (hibernate/stop/
+	// prevent-launch/notify) and cushion. OFF by default because these actions are destructive
+	// (auto-stopping real instances); auto-actions stay advisory until an operator opts in.
+	BudgetEnforcementEnabled         bool `json:"budget_enforcement_enabled"`          // opt-in; default false
+	BudgetEnforcementIntervalMinutes int  `json:"budget_enforcement_interval_minutes"` // default 10; floored at 1
 }
 
 // DefaultConfig returns the default daemon configuration
@@ -35,6 +42,8 @@ func DefaultConfig() *Config {
 		MonitoringIntervalSeconds:         60,     // Future: default monitoring interval
 		CostReconciliationEnabled:         false,  // Opt-in: CE reconciliation off by default
 		CostReconciliationIntervalMinutes: 1440,   // Default: daily
+		BudgetEnforcementEnabled:          false,  // Opt-in: auto-actions off by default
+		BudgetEnforcementIntervalMinutes:  10,     // Default: evaluate every 10 minutes
 	}
 }
 
@@ -46,6 +55,7 @@ func LoadConfig() (*Config, error) {
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		config := DefaultConfig()
 		applyCostReconciliationEnv(config)
+		applyBudgetEnforcementEnv(config)
 		return config, nil
 	}
 
@@ -62,6 +72,7 @@ func LoadConfig() (*Config, error) {
 	}
 
 	applyCostReconciliationEnv(config)
+	applyBudgetEnforcementEnv(config)
 	return config, nil
 }
 
@@ -78,6 +89,23 @@ func applyCostReconciliationEnv(config *Config) {
 	if v := os.Getenv("PRISM_COST_RECONCILIATION_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			config.CostReconciliationIntervalMinutes = int(d.Minutes())
+		}
+	}
+}
+
+// applyBudgetEnforcementEnv lets env vars override the file/default for budget enforcement (env wins
+// over file wins over default). PRISM_BUDGET_ENFORCEMENT is a bool ("true"/"false");
+// PRISM_BUDGET_ENFORCEMENT_INTERVAL is a Go duration string (e.g. "10m", "1h").
+func applyBudgetEnforcementEnv(config *Config) {
+	switch os.Getenv("PRISM_BUDGET_ENFORCEMENT") {
+	case "true", "1":
+		config.BudgetEnforcementEnabled = true
+	case "false", "0":
+		config.BudgetEnforcementEnabled = false
+	}
+	if v := os.Getenv("PRISM_BUDGET_ENFORCEMENT_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			config.BudgetEnforcementIntervalMinutes = int(d.Minutes())
 		}
 	}
 }
@@ -121,6 +149,17 @@ func (c *Config) GetRetentionDuration() time.Duration {
 func (c *Config) GetCostReconciliationInterval() time.Duration {
 	const floor = time.Hour
 	d := time.Duration(c.CostReconciliationIntervalMinutes) * time.Minute
+	if d < floor {
+		return floor
+	}
+	return d
+}
+
+// GetBudgetEnforcementInterval returns the enforcement evaluation interval, clamped to a 1-minute
+// floor so a misconfigured value can't spin the per-project pass every tick.
+func (c *Config) GetBudgetEnforcementInterval() time.Duration {
+	const floor = time.Minute
+	d := time.Duration(c.BudgetEnforcementIntervalMinutes) * time.Minute
 	if d < floor {
 		return floor
 	}

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -489,10 +489,25 @@ func NewServer(port string) (*Server, error) {
 			}
 			return out, nil
 		}, server.testMode, opts)
-		stateMonitor.SetTickHook(func() { observer.Observe(context.Background()) })
 		if opts.reconcileEnabled && opts.billedCost != nil {
 			logger.Info("Budget cost reconciliation enabled", "interval", opts.reconcileInterval.String())
 		}
+
+		// Live budget enforcement (#656): opt-in, off by default. When enabled, evaluate each project's
+		// budget against the ledger and fire its auto-actions/cushion. Shares the single StateMonitor
+		// tick hook with the observer (only one hook is supported), running enforcement after accrual so
+		// it sees the freshest spend.
+		enforcer := server.newBudgetEnforcer(config)
+		if enforcer != nil && enforcer.enabled {
+			logger.Info("Budget enforcement enabled", "interval", enforcer.interval.String())
+		}
+		stateMonitor.SetTickHook(func() {
+			ctx := context.Background()
+			observer.Observe(ctx)
+			if enforcer != nil {
+				enforcer.Enforce(ctx)
+			}
+		})
 	}
 
 	// Initialize course manager (v0.14.0 - Issue #45)
@@ -521,9 +536,10 @@ func NewServer(port string) (*Server, error) {
 		logger.Info(getReducedModeBanner())
 	}
 
-	// Phase 3c (#653): the BudgetTracker that owned the auto-action executor and the alert dispatcher
-	// is retired. Live budget enforcement (hibernate/stop/prevent-launch via the engine ActionSink)
-	// and alert-dispatcher wiring are tracked as a net-new feature (#656); this path was inert in prod.
+	// Live budget enforcement (#656) is wired above via newBudgetEnforcer + the shared StateMonitor
+	// tick hook (see pkg/daemon/budget_enforcer.go). It is opt-in (BudgetEnforcementEnabled) and off by
+	// default. The Server implements project.ActionExecutor (ExecuteHibernateAll/StopAll/PreventLaunch)
+	// and the enforcer selects a Slack/log alert dispatcher.
 
 	// Initialize recovery and health monitoring (need server reference)
 	server.recoveryManager = NewRecoveryManager(stabilityManager, nil) // Will be set after server creation

--- a/pkg/types/project.go
+++ b/pkg/types/project.go
@@ -244,6 +244,9 @@ type CushionBudgetConfig struct {
 	Mode               string   `json:"mode"`
 	NotifyBeforeAction bool     `json:"notify_before_action"`
 	WarnLeadHours      int      `json:"warn_lead_hours"`
+	// LastTriggeredAt records when the cushion last fired, for fire-once-per-budget-period dedup by
+	// the live enforcer (#656). Nil = never fired.
+	LastTriggeredAt *time.Time `json:"last_triggered_at,omitempty"`
 }
 
 // BudgetAlert defines a spending threshold that triggers notifications


### PR DESCRIPTION
## #656 — auto-actions fire again, on the spend ledger

Per-project budget auto-actions (`AutoActions[]`: threshold %% → hibernate/stop/prevent-launch/notify) and the safety cushion (headroom → one action) are persisted config with working executors — but nothing evaluated them after the `BudgetTracker` was retired (its `checkBudgetAlerts` loop went with it). Configuring an auto-action has been a no-op since Phase 3c. This restores enforcement, now folding the `budgetengine` spend ledger.

### Design
- **New `pkg/daemon/budget_enforcer.go`** — `budgetEnforcer.Enforce` runs a **throttled** per-project pass on the StateMonitor tick (shares the single tick hook with the spend observer: observe, then enforce). For each budgeted project it folds the ledger via the existing **`Server.budgetStatus`** (the same numbers the API returns), then:
  - **AutoActions**: fire when `SpentPercentage >= action.Threshold` — hibernate/stop/prevent-launch via the surviving `Server.ExecuteHibernateAll/StopAll/PreventLaunch` (Server is the `project.ActionExecutor`); notify-only sends an alert.
  - **Cushion**: fire when `remaining <= headroom`, via the surviving `project.CushionEvaluator`.
  - **Dedup**: fire-once-per-budget-period via `LastTriggered` timestamps, keyed off `budgetWindow` (a monthly budget re-arms each month). Persisted through `SetProjectBudget` only when something fired.
- **Alerts**: Slack webhook dispatcher when `PRISM_SLACK_WEBHOOK` is set (reviving the retired selection), else log dispatcher.
- Injected collaborators (executor / status fn / list / save) → unit-testable with no AWS.

### Gating — opt-in, OFF by default
These are destructive (auto-stopping real instances), so enforcement requires an explicit opt-in: `budget_enforcement_enabled` (config) or `PRISM_BUDGET_ENFORCEMENT=true`. Cadence: `budget_enforcement_interval_minutes` (default 10, 1-minute floor). Mirrors the cost-reconciliation config idiom exactly.

### Why not the engine ActionSink?
Deliberately not used: the reactive `ActionSink`/`Notify` path is **verdict-less** (hands over raw `BurnState`), while the trigger logic here is threshold-based and prism-specific (config gating, dedup, persistence). Folding via `budgetStatus` keeps enforcement and the status readout consistent. Documented so a later phase can adopt the push path if the model changes.

### Verification
- `go build`/`vet`/`gofmt`/`golangci-lint` (my files clean)/`govulncheck` clean; `go test ./...` green.
- `budget_enforcer_test.go`: fire; dedup-within-period + re-arm-next-period; notify-only calls no executor; cushion triggers correct mode + stamps `LastTriggeredAt`; gating-off is a no-op; below-threshold and disabled-action don't fire. Stub executor + capturing alerter — no AWS.

### Out of scope
- Auto-resume / un-hibernate when spend drops or a new period begins (enforcement is one-directional here; `AllowLaunches` exists for a manual/GUI follow-up).
- GUI surfacing of enforcement state.

Closes #656