### PR TITLE
feat(pricing): on-demand instance rates from truffle (Phase 3d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **On-demand instance pricing now uses truffle (spawn adoption Phase 3d).** The
+  on-demand compute rate recorded on every instance (`Instance.HourlyRate`) is
+  now sourced from `github.com/spore-host/truffle` via a new
+  `OnDemandPricingClient` (`pkg/aws/ondemand_pricing.go`), mirroring the spot
+  path shipped in #659. This completes the truffle pricing consolidation:
+  truffle wraps the AWS Price List API with a 24h cache and a static fallback and
+  is **region-aware**, replacing Prism's hand-rolled Price List query whose
+  static fallback table was us-east-1-only — so per-region estimates (e.g.
+  us-west-2) are now accurate rather than us-east-1 approximations. The static
+  `getHourlyRate` estimate is retained purely as the on-truffle-error fallback,
+  so `HourlyRate` is never left at 0 on the list/refresh path. The old on-demand
+  Price List code (`GetInstanceHourlyRate`/`queryPricingAPI`/`parsePriceFromJSON`
+  + its 24h cache) is removed; `PricingClient` now holds only EBS volume rates
+  (truffle has no storage pricing). Spot/on-demand rate selection
+  (`EffectiveComputeRate`) is unchanged. Verified against real AWS (t3.large
+  us-west-2 → the correct regional list price).
+
 ### Added
 - **spawn adoption — opt-in launch capabilities (Phase 3a).** Three new opt-in
   `prism workspace launch` flags, all default-off (empty/false = today's

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/health v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.52.0
-	github.com/aws/aws-sdk-go-v2/service/pricing v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.71.0
@@ -48,6 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.73.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ebs v1.34.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.55.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/pricing v1.43.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.33.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 // indirect

--- a/pkg/aws/manager.go
+++ b/pkg/aws/manager.go
@@ -72,18 +72,19 @@ func generateDCVPassword() string {
 
 // Manager handles all AWS operations
 type Manager struct {
-	cfg               aws.Config
-	ec2               EC2ClientInterface
-	efs               EFSClientInterface
-	iam               *iam.Client
-	ssm               SSMClientInterface
-	sts               STSClientInterface
-	region            string
-	templates         map[string]ctypes.Template
-	pricingClient     *PricingClient
-	spotPricingClient *SpotPricingClient
-	discountConfig    ctypes.DiscountConfig
-	stateManager      StateManagerInterface
+	cfg                   aws.Config
+	ec2                   EC2ClientInterface
+	efs                   EFSClientInterface
+	iam                   *iam.Client
+	ssm                   SSMClientInterface
+	sts                   STSClientInterface
+	region                string
+	templates             map[string]ctypes.Template
+	pricingClient         *PricingClient // EBS volume rates (on-demand compute moved to truffle)
+	onDemandPricingClient *OnDemandPricingClient
+	spotPricingClient     *SpotPricingClient
+	discountConfig        ctypes.DiscountConfig
+	stateManager          StateManagerInterface
 
 	// launcher is the instance launch/lifecycle engine (spawn adoption).
 	// Defaults to the EC2-backed ec2Launcher; swappable for tests and, in a
@@ -171,10 +172,12 @@ func NewManager(opts ...ManagerOptions) (*Manager, error) {
 	// Initialize Universal Version System (v0.5.4)
 	amiDiscovery := NewAMIDiscovery(ssmClient)
 
-	// Initialize AWS Pricing API client with caching
+	// Initialize AWS Pricing client (EBS volume rates; on-demand compute moved to truffle)
 	pricingClient := NewPricingClient(cfg)
 
-	// Initialize spot pricing client (truffle-backed) for accurate spot-instance estimates (#659)
+	// Initialize on-demand + spot pricing clients (truffle-backed) for accurate
+	// per-region instance-rate estimates (spawn adoption; spot from #659)
+	onDemandPricingClient := NewOnDemandPricingClient(cfg)
 	spotPricingClient := NewSpotPricingClient(cfg)
 
 	// Initialize Quota and Availability Management (v0.7.0)
@@ -184,24 +187,25 @@ func NewManager(opts ...ManagerOptions) (*Manager, error) {
 
 	// Create manager first (needed for adapter)
 	manager := &Manager{
-		cfg:                 cfg,
-		ec2:                 ec2Client,
-		efs:                 efsClient,
-		iam:                 iamClient,
-		ssm:                 ssmClient,
-		sts:                 stsClient,
-		region:              region,
-		templates:           getTemplates(),
-		pricingClient:       pricingClient,
-		spotPricingClient:   spotPricingClient,
-		discountConfig:      ctypes.DiscountConfig{}, // No discounts by default
-		stateManager:        stateManager,
-		amiResolver:         amiResolver,
-		amiDiscovery:        amiDiscovery,
-		architectureCache:   make(map[string]string), // Initialize architecture cache
-		quotaManager:        quotaManager,
-		availabilityManager: availabilityManager,
-		healthMonitor:       healthMonitor,
+		cfg:                   cfg,
+		ec2:                   ec2Client,
+		efs:                   efsClient,
+		iam:                   iamClient,
+		ssm:                   ssmClient,
+		sts:                   stsClient,
+		region:                region,
+		templates:             getTemplates(),
+		pricingClient:         pricingClient,
+		onDemandPricingClient: onDemandPricingClient,
+		spotPricingClient:     spotPricingClient,
+		discountConfig:        ctypes.DiscountConfig{}, // No discounts by default
+		stateManager:          stateManager,
+		amiResolver:           amiResolver,
+		amiDiscovery:          amiDiscovery,
+		architectureCache:     make(map[string]string), // Initialize architecture cache
+		quotaManager:          quotaManager,
+		availabilityManager:   availabilityManager,
+		healthMonitor:         healthMonitor,
 	}
 
 	// Default the launch/lifecycle engine to the hybrid launcher: Prism's own
@@ -2740,23 +2744,25 @@ func (c *InstanceStateConverter) isHibernationConfigured(ec2Instance ec2types.In
 
 // InstanceBuilder builds Prism instance objects (Builder Pattern - SOLID)
 type InstanceBuilder struct {
-	tagExtractor      *InstanceTagExtractor
-	stateConverter    *InstanceStateConverter
-	ec2Client         EC2ClientInterface
-	pricingClient     *PricingClient
-	spotPricingClient *SpotPricingClient
-	region            string
+	tagExtractor          *InstanceTagExtractor
+	stateConverter        *InstanceStateConverter
+	ec2Client             EC2ClientInterface
+	pricingClient         *PricingClient // EBS volume rates only (compute rates moved to truffle)
+	onDemandPricingClient *OnDemandPricingClient
+	spotPricingClient     *SpotPricingClient
+	region                string
 }
 
 // NewInstanceBuilder creates instance builder
-func NewInstanceBuilder(ec2Client EC2ClientInterface, pricingClient *PricingClient, spotPricingClient *SpotPricingClient, region string) *InstanceBuilder {
+func NewInstanceBuilder(ec2Client EC2ClientInterface, pricingClient *PricingClient, onDemandPricingClient *OnDemandPricingClient, spotPricingClient *SpotPricingClient, region string) *InstanceBuilder {
 	return &InstanceBuilder{
-		tagExtractor:      &InstanceTagExtractor{},
-		stateConverter:    &InstanceStateConverter{},
-		ec2Client:         ec2Client,
-		pricingClient:     pricingClient,
-		spotPricingClient: spotPricingClient,
-		region:            region,
+		tagExtractor:          &InstanceTagExtractor{},
+		stateConverter:        &InstanceStateConverter{},
+		ec2Client:             ec2Client,
+		pricingClient:         pricingClient,
+		onDemandPricingClient: onDemandPricingClient,
+		spotPricingClient:     spotPricingClient,
+		region:                region,
 	}
 }
 
@@ -2901,12 +2907,12 @@ func (b *InstanceBuilder) BuildInstance(ec2Instance ec2types.Instance, localStat
 	// Calculate cost metrics based on instance type and runtime
 	instanceType := string(ec2Instance.InstanceType)
 
-	// Get accurate hourly rate from AWS Pricing API (with fallback to estimates)
+	// Get the accurate on-demand hourly rate via truffle (with fallback to estimates)
 	ctx := context.Background()
-	hourlyRate, err := b.pricingClient.GetInstanceHourlyRate(ctx, b.region, instanceType)
+	hourlyRate, err := b.onDemandPricingClient.GetOnDemandHourlyRate(ctx, instanceType, b.region)
 	if err != nil {
-		// Fall back to hardcoded estimate on error (pricing API failure)
-		log.Printf("Warning: Pricing API failed for %s in %s: %v. Using estimate.", instanceType, b.region, err)
+		// Fall back to hardcoded estimate on error (pricing lookup failure)
+		log.Printf("Warning: on-demand pricing failed for %s in %s: %v. Using estimate.", instanceType, b.region, err)
 		hourlyRate = getHourlyRate(instanceType)
 	}
 
@@ -2970,10 +2976,10 @@ type InstanceListProcessor struct {
 }
 
 // NewInstanceListProcessor creates instance list processor
-func NewInstanceListProcessor(ec2Client EC2ClientInterface, pricingClient *PricingClient, spotPricingClient *SpotPricingClient, region string) *InstanceListProcessor {
+func NewInstanceListProcessor(ec2Client EC2ClientInterface, pricingClient *PricingClient, onDemandPricingClient *OnDemandPricingClient, spotPricingClient *SpotPricingClient, region string) *InstanceListProcessor {
 	return &InstanceListProcessor{
 		stateLoader:     &StateLoader{},
-		instanceBuilder: NewInstanceBuilder(ec2Client, pricingClient, spotPricingClient, region),
+		instanceBuilder: NewInstanceBuilder(ec2Client, pricingClient, onDemandPricingClient, spotPricingClient, region),
 	}
 }
 
@@ -3018,7 +3024,7 @@ func (m *Manager) GetInstance(instanceID string) (*ctypes.Instance, error) {
 	}
 
 	// Process the single instance
-	processor := NewInstanceListProcessor(m.ec2, m.pricingClient, m.spotPricingClient, m.region)
+	processor := NewInstanceListProcessor(m.ec2, m.pricingClient, m.onDemandPricingClient, m.spotPricingClient, m.region)
 	instances := processor.ProcessReservations(result.Reservations)
 
 	if len(instances) == 0 {
@@ -3091,7 +3097,7 @@ func (m *Manager) ListInstances() ([]ctypes.Instance, error) {
 		}
 
 		// Process instances from this region
-		processor := NewInstanceListProcessor(regionalClient, m.pricingClient, m.spotPricingClient, region)
+		processor := NewInstanceListProcessor(regionalClient, m.pricingClient, m.onDemandPricingClient, m.spotPricingClient, region)
 		regionalInstances := processor.ProcessReservations(result.Reservations)
 
 		// Ensure each instance has the region set and merge cached metadata

--- a/pkg/aws/ondemand_pricing.go
+++ b/pkg/aws/ondemand_pricing.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	truffle "github.com/spore-host/truffle/pkg/aws"
+)
+
+// On-demand pricing via truffle (spawn adoption, follows the spot path #659).
+// The on-demand hourly rate is the baseline compute cost prism records on every
+// instance (Instance.HourlyRate). Pricing is delegated to spore.host's truffle
+// (github.com/spore-host/truffle) — its HourlyRate(ctx, type, region, "on-demand")
+// wraps the AWS Price List API with a 24h cache AND a static fallback, and is
+// region-aware (prism's former static getHourlyRate table was us-east-1-only),
+// so this both removes hand-rolled Price List code and improves per-region
+// accuracy. Truffle already handles spot here too (see SpotPricingClient); this
+// is the on-demand twin.
+
+// onDemandRateFetcher is the narrow slice of truffle used here, extracted so
+// tests can inject a fake without live AWS. *truffle.Client satisfies it. It is
+// the same signature spotRateFetcher uses — only the model string differs.
+type onDemandRateFetcher interface {
+	HourlyRate(ctx context.Context, instanceType, region, model string) (float64, error)
+}
+
+// OnDemandPricingClient resolves and caches per-(instanceType,region) on-demand
+// rates. On-demand list prices change rarely, so a captured value is cached for
+// the process lifetime (truffle also caches internally with a 24h TTL).
+type OnDemandPricingClient struct {
+	fetcher onDemandRateFetcher
+	mu      sync.RWMutex
+	cache   map[string]float64
+}
+
+// NewOnDemandPricingClient builds an on-demand pricing client over truffle from
+// the given AWS config.
+func NewOnDemandPricingClient(cfg awssdk.Config) *OnDemandPricingClient {
+	return &OnDemandPricingClient{
+		fetcher: truffle.NewClientFromConfig(cfg),
+		cache:   map[string]float64{},
+	}
+}
+
+// GetOnDemandHourlyRate returns the current on-demand $/hr for an instance type
+// in a region. It errors (rather than falling back) so callers decide the
+// fallback — BuildInstance treats an error as "use the static getHourlyRate
+// estimate + log", never leaving the rate at 0.
+func (c *OnDemandPricingClient) GetOnDemandHourlyRate(ctx context.Context, instanceType, region string) (float64, error) {
+	if c == nil || c.fetcher == nil {
+		return 0, fmt.Errorf("on-demand pricing client not configured")
+	}
+	key := region + "/" + instanceType
+
+	c.mu.RLock()
+	cached, ok := c.cache[key]
+	c.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	rate, err := c.fetcher.HourlyRate(ctx, instanceType, region, "on-demand")
+	if err != nil {
+		return 0, err
+	}
+	if rate <= 0 {
+		return 0, fmt.Errorf("no on-demand price available for %s in %s", instanceType, region)
+	}
+
+	c.mu.Lock()
+	c.cache[key] = rate
+	c.mu.Unlock()
+	return rate, nil
+}

--- a/pkg/aws/ondemand_pricing_test.go
+++ b/pkg/aws/ondemand_pricing_test.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeOnDemandFetcher records calls and returns a scripted rate/error.
+type fakeOnDemandFetcher struct {
+	rate  float64
+	err   error
+	calls int
+}
+
+func (f *fakeOnDemandFetcher) HourlyRate(_ context.Context, _, _, model string) (float64, error) {
+	f.calls++
+	switch model {
+	case "", "on-demand", "ondemand", "on_demand":
+		// accepted on-demand model strings
+	default:
+		return 0, errors.New("expected on-demand model, got " + model)
+	}
+	return f.rate, f.err
+}
+
+func newTestOnDemandClient(f onDemandRateFetcher) *OnDemandPricingClient {
+	return &OnDemandPricingClient{fetcher: f, cache: map[string]float64{}}
+}
+
+// TestOnDemandPricingClient_Caches: a successful lookup is cached, so a repeat
+// call for the same (type,region) does not hit the fetcher again.
+func TestOnDemandPricingClient_Caches(t *testing.T) {
+	f := &fakeOnDemandFetcher{rate: 0.0928}
+	c := newTestOnDemandClient(f)
+	ctx := context.Background()
+
+	got, err := c.GetOnDemandHourlyRate(ctx, "t3.large", "us-west-2")
+	if err != nil || got != 0.0928 {
+		t.Fatalf("first lookup = %v, %v; want 0.0928, nil", got, err)
+	}
+	got, err = c.GetOnDemandHourlyRate(ctx, "t3.large", "us-west-2")
+	if err != nil || got != 0.0928 {
+		t.Fatalf("second lookup = %v, %v; want 0.0928, nil", got, err)
+	}
+	if f.calls != 1 {
+		t.Fatalf("fetcher called %d times, want 1 (second served from cache)", f.calls)
+	}
+}
+
+// TestOnDemandPricingClient_Error propagates the fetcher error (caller decides
+// fallback) and does not cache.
+func TestOnDemandPricingClient_Error(t *testing.T) {
+	f := &fakeOnDemandFetcher{err: errors.New("no on-demand price")}
+	c := newTestOnDemandClient(f)
+	if _, err := c.GetOnDemandHourlyRate(context.Background(), "t3.large", "us-west-2"); err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}
+
+// TestOnDemandPricingClient_ZeroIsError: a non-positive rate is unavailable.
+func TestOnDemandPricingClient_ZeroIsError(t *testing.T) {
+	f := &fakeOnDemandFetcher{rate: 0}
+	c := newTestOnDemandClient(f)
+	if _, err := c.GetOnDemandHourlyRate(context.Background(), "t3.large", "us-west-2"); err == nil {
+		t.Fatal("zero rate should be an error")
+	}
+}
+
+// TestOnDemandPricingClient_NilSafe: a nil client fails soft, never panics.
+func TestOnDemandPricingClient_NilSafe(t *testing.T) {
+	var c *OnDemandPricingClient
+	if _, err := c.GetOnDemandHourlyRate(context.Background(), "t3.large", "us-west-2"); err == nil {
+		t.Fatal("nil client should return an error, not panic")
+	}
+}

--- a/pkg/aws/pricing.go
+++ b/pkg/aws/pricing.go
@@ -1,243 +1,25 @@
 package aws
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"sync"
-	"time"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/pricing"
-	pricingtypes "github.com/aws/aws-sdk-go-v2/service/pricing/types"
 )
 
-// PricingCache caches AWS pricing data to avoid repeated API calls
-type PricingCache struct {
-	mu          sync.RWMutex
-	prices      map[string]float64 // key: "region:instanceType"
-	lastUpdated time.Time
-	ttl         time.Duration
+// PricingClient provides EBS volume pricing. On-demand and spot instance
+// compute rates are sourced from spore.host's truffle (see OnDemandPricingClient
+// and SpotPricingClient); the former AWS Price List API path lived here but was
+// retired when compute pricing moved to truffle (region-aware, cached, with a
+// static fallback). EBS volume rates remain here — truffle has no storage
+// pricing — as a small static table.
+type PricingClient struct{}
+
+// NewPricingClient creates a pricing client. The AWS config is accepted for
+// signature stability with the other pricing clients; EBS rates are static so
+// no AWS client is built.
+func NewPricingClient(_ aws.Config) *PricingClient {
+	return &PricingClient{}
 }
 
-// NewPricingCache creates a new pricing cache with 24-hour TTL
-func NewPricingCache() *PricingCache {
-	return &PricingCache{
-		prices: make(map[string]float64),
-		ttl:    24 * time.Hour,
-	}
-}
-
-// Get retrieves a cached price if available and not expired
-func (c *PricingCache) Get(region, instanceType string) (float64, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	if time.Since(c.lastUpdated) > c.ttl {
-		return 0, false
-	}
-
-	key := fmt.Sprintf("%s:%s", region, instanceType)
-	price, exists := c.prices[key]
-	return price, exists
-}
-
-// Set stores a price in the cache
-func (c *PricingCache) Set(region, instanceType string, price float64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	key := fmt.Sprintf("%s:%s", region, instanceType)
-	c.prices[key] = price
-	c.lastUpdated = time.Now()
-}
-
-// PricingClient wraps AWS Pricing API with caching
-type PricingClient struct {
-	client *pricing.Client
-	cache  *PricingCache
-}
-
-// NewPricingClient creates a new pricing client with the given AWS config
-func NewPricingClient(cfg aws.Config) *PricingClient {
-	// AWS Pricing API is only available in us-east-1
-	pricingCfg := cfg.Copy()
-	pricingCfg.Region = "us-east-1"
-
-	return &PricingClient{
-		client: pricing.NewFromConfig(pricingCfg),
-		cache:  NewPricingCache(),
-	}
-}
-
-// GetInstanceHourlyRate fetches the on-demand hourly rate for an instance type in a region
-func (p *PricingClient) GetInstanceHourlyRate(ctx context.Context, region, instanceType string) (float64, error) {
-	// Check cache first
-	if price, ok := p.cache.Get(region, instanceType); ok {
-		return price, nil
-	}
-
-	// Query AWS Pricing API
-	price, err := p.queryPricingAPI(ctx, region, instanceType)
-	if err != nil {
-		// Fall back to hardcoded estimates on error
-		return getHourlyRate(instanceType), fmt.Errorf("pricing API failed, using estimate: %w", err)
-	}
-
-	// Cache the result
-	p.cache.Set(region, instanceType, price)
-	return price, nil
-}
-
-// queryPricingAPI queries the AWS Pricing API for instance pricing
-func (p *PricingClient) queryPricingAPI(ctx context.Context, region, instanceType string) (float64, error) {
-	// Map region codes to AWS Pricing API location names
-	regionLocations := map[string]string{
-		"us-east-1":      "US East (N. Virginia)",
-		"us-east-2":      "US East (Ohio)",
-		"us-west-1":      "US West (N. California)",
-		"us-west-2":      "US West (Oregon)",
-		"eu-west-1":      "EU (Ireland)",
-		"eu-west-2":      "EU (London)",
-		"eu-west-3":      "EU (Paris)",
-		"eu-central-1":   "EU (Frankfurt)",
-		"ap-southeast-1": "Asia Pacific (Singapore)",
-		"ap-southeast-2": "Asia Pacific (Sydney)",
-		"ap-northeast-1": "Asia Pacific (Tokyo)",
-		"ap-south-1":     "Asia Pacific (Mumbai)",
-	}
-
-	location, ok := regionLocations[region]
-	if !ok {
-		return 0, fmt.Errorf("unknown region: %s", region)
-	}
-
-	// Build filters for the pricing query
-	filters := []pricingtypes.Filter{
-		{
-			Field: aws.String("ServiceCode"),
-			Value: aws.String("AmazonEC2"),
-			Type:  pricingtypes.FilterTypeTermMatch,
-		},
-		{
-			Field: aws.String("instanceType"),
-			Value: aws.String(instanceType),
-			Type:  pricingtypes.FilterTypeTermMatch,
-		},
-		{
-			Field: aws.String("location"),
-			Value: aws.String(location),
-			Type:  pricingtypes.FilterTypeTermMatch,
-		},
-		{
-			Field: aws.String("tenancy"),
-			Value: aws.String("Shared"),
-			Type:  pricingtypes.FilterTypeTermMatch,
-		},
-		{
-			Field: aws.String("operatingSystem"),
-			Value: aws.String("Linux"),
-			Type:  pricingtypes.FilterTypeTermMatch,
-		},
-		{
-			Field: aws.String("preInstalledSw"),
-			Value: aws.String("NA"),
-			Type:  pricingtypes.FilterTypeTermMatch,
-		},
-		{
-			Field: aws.String("capacitystatus"),
-			Value: aws.String("Used"),
-			Type:  pricingtypes.FilterTypeTermMatch,
-		},
-	}
-
-	// Query the pricing API
-	input := &pricing.GetProductsInput{
-		ServiceCode: aws.String("AmazonEC2"),
-		Filters:     filters,
-		MaxResults:  aws.Int32(1),
-	}
-
-	result, err := p.client.GetProducts(ctx, input)
-	if err != nil {
-		return 0, fmt.Errorf("pricing API query failed: %w", err)
-	}
-
-	if len(result.PriceList) == 0 {
-		return 0, fmt.Errorf("no pricing data found for %s in %s", instanceType, region)
-	}
-
-	// Parse the pricing data (AWS returns JSON strings)
-	price, err := p.parsePriceFromJSON(result.PriceList[0])
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse pricing data: %w", err)
-	}
-
-	return price, nil
-}
-
-// parsePriceFromJSON extracts the on-demand hourly price from AWS Pricing API JSON response
-func (p *PricingClient) parsePriceFromJSON(priceListJSON string) (float64, error) {
-	var priceData map[string]interface{}
-	if err := json.Unmarshal([]byte(priceListJSON), &priceData); err != nil {
-		return 0, fmt.Errorf("failed to unmarshal price data: %w", err)
-	}
-
-	// Navigate the nested JSON structure to find on-demand pricing
-	// Structure: terms.OnDemand.{offerTermCode}.priceDimensions.{dimensionCode}.pricePerUnit.USD
-	terms, ok := priceData["terms"].(map[string]interface{})
-	if !ok {
-		return 0, fmt.Errorf("terms field not found")
-	}
-
-	onDemand, ok := terms["OnDemand"].(map[string]interface{})
-	if !ok {
-		return 0, fmt.Errorf("OnDemand terms not found")
-	}
-
-	// Get the first (and usually only) on-demand offer
-	for _, offerData := range onDemand {
-		offer, ok := offerData.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		priceDimensions, ok := offer["priceDimensions"].(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		// Get the first price dimension
-		for _, dimensionData := range priceDimensions {
-			dimension, ok := dimensionData.(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			pricePerUnit, ok := dimension["pricePerUnit"].(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			usdPrice, ok := pricePerUnit["USD"].(string)
-			if !ok {
-				continue
-			}
-
-			// Parse the price string to float64
-			var price float64
-			if _, err := fmt.Sscanf(usdPrice, "%f", &price); err != nil {
-				return 0, fmt.Errorf("failed to parse price: %w", err)
-			}
-
-			return price, nil
-		}
-	}
-
-	return 0, fmt.Errorf("price not found in response")
-}
-
-// GetEBSVolumeHourlyRate calculates the hourly cost for an EBS volume
+// GetEBSVolumeHourlyRate calculates the hourly cost for an EBS volume.
 func (p *PricingClient) GetEBSVolumeHourlyRate(volumeType string, sizeGB int) float64 {
 	// EBS pricing per GB-month, converted to per GB-hour
 	// These are us-east-1 rates as of 2024


### PR DESCRIPTION
## Summary

Sources on-demand EC2 instance pricing from **`github.com/spore-host/truffle`**, completing the truffle pricing consolidation begun with spot in #659. This is Phase 3d of the spawn-adoption milestone.

> **Stacked on #666** (Phases 0–3a). Base is `feat/spawn-adoption-phase0`; this PR is just the on-demand-pricing diff. GitHub will retarget to `main` once #666 merges.

## What changed
- New `OnDemandPricingClient` (`pkg/aws/ondemand_pricing.go`) wraps `truffle.HourlyRate(ctx, type, region, "on-demand")`, mirroring the shipped `SpotPricingClient` exactly (narrow fetcher interface for fakes, per-(type,region) cache, nil-safe, `rate<=0`→error).
- `InstanceBuilder.BuildInstance` now sources `Instance.HourlyRate` via the on-demand client. The static `getHourlyRate` estimate is retained **only** as the on-truffle-error fallback, so the rate is never left at 0 on the list/refresh hot path.
- Removed the dead hand-rolled Price List code (`GetInstanceHourlyRate`/`queryPricingAPI`/`parsePriceFromJSON` + the 24h `PricingCache` + `pricing.NewFromConfig` client). `PricingClient` now holds only `GetEBSVolumeHourlyRate` — truffle has no storage pricing, so EBS rates stay put.
- Spot/on-demand rate selection (`EffectiveComputeRate`) and the spot capture path are untouched.

## Why it's better
truffle wraps the AWS Price List API with a 24h cache **and a static fallback** — the same shape Prism had — but is **region-aware**. Prism's old static fallback table was us-east-1-only, so per-region estimates were approximations. Now they're accurate.

## Testing
- Unit: `fakeOnDemandFetcher` mirror of the spot test (cache-once, error/zero propagation, nil-safe, on-demand model-string assertion).
- `go build/vet/test ./...` green; gofmt/goimports/golangci clean on changed files; govulncheck 0 called vulnerabilities.
- **Live against real AWS (zero cost):** `t3.large` in `us-west-2` → `$0.0832/hr` (the correct regional list price — demonstrates the region-aware gain vs the old us-east-1 static number).

Net −194 LOC.
