### PR TITLE
fix(lint): migrate .golangci.yml to golangci-lint v2 schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,33 +1,19 @@
 # Prism golangci-lint configuration
-# Compatible with golangci-lint v2.5+
-
-version: 2
+# golangci-lint v2 schema (v2.5+). Validate with: golangci-lint config verify
+version: "2"
 
 run:
   timeout: 5m
   tests: true
-  skip-dirs:
-    - vendor
-    - node_modules
-    - .git
-    - cmd/prism-gui/frontend
-
-output:
-  format: colored-line-number
 
 linters:
+  # Start from the standard set (errcheck, govet, ineffassign, staticcheck,
+  # unused) and add the extras below.
+  default: standard
   enable:
-    # Default enabled linters
-    - errcheck
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-
-    # Additional useful linters
     - bodyclose
-    - cyclop        # cyclomatic complexity
-    - gocognit      # cognitive complexity
+    - cyclop # cyclomatic complexity
+    - gocognit # cognitive complexity
     - goconst
     - gocritic
     - gosec
@@ -39,38 +25,40 @@ linters:
     - unparam
     - whitespace
 
-linters-settings:
-  cyclop:
-    max-complexity: 15
+  settings:
+    cyclop:
+      max-complexity: 15
+    gocognit:
+      min-complexity: 20
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gosec:
+      excludes: []
+    revive:
+      confidence: 0.8
 
-  gocognit:
-    min-complexity: 20
-
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-
-  gosec:
-    excludes: []
-
-  revive:
-    confidence: 0.8
+  exclusions:
+    # Directories not linted (moved from run.skip-dirs).
+    paths:
+      - vendor
+      - node_modules
+      - .git
+      - cmd/prism-gui/frontend
+    rules:
+      # Relax noisy linters in test files.
+      - path: _test\.go
+        linters:
+          - cyclop
+          - errcheck
+          - gosec
+          - goconst
+      # Allow complex main functions.
+      - path: cmd/.*/main\.go
+        linters:
+          - gocognit
+          - cyclop
 
 issues:
   max-issues-per-linter: 50
   max-same-issues: 3
-
-  exclude-rules:
-    # Exclude some linters from test files
-    - path: _test\.go
-      linters:
-        - cyclop
-        - errcheck
-        - gosec
-        - goconst
-
-    # Allow complex main functions
-    - path: cmd/.*/main\.go
-      linters:
-        - gocognit
-        - cyclop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`.golangci.yml` migrated to the golangci-lint v2 schema.** The config
+  declared `version: 2` but used v1-schema keys (`linters-settings`,
+  `issues.exclude-rules`, `run.skip-dirs`, `output.format`), which golangci-lint
+  v2 silently rejected and replaced with defaults — so `make lint` was running
+  with the wrong linter set (cyclop threshold 10 instead of 15, test-file
+  exclusions ignored). Rewrote to the valid v2 layout (`linters.settings`,
+  `linters.exclusions.rules/paths`, `default: standard`); `golangci-lint config
+  verify` now passes and the intended thresholds/exclusions apply. Note:
+  `make lint` is a local developer tool (CI gates on `go vet` + `gofmt`, not
+  golangci-lint); with the config now honored it surfaces pre-existing lint debt
+  to be addressed separately.
+
 ### Changed
 - **On-demand instance pricing now uses truffle (spawn adoption Phase 3d).** The
   on-demand compute rate recorded on every instance (`Instance.HourlyRate`) is


### PR DESCRIPTION
## Summary

`.golangci.yml` declared `version: 2` but used v1-schema keys (`linters-settings`, `issues.exclude-rules`, `run.skip-dirs`, `output.format`). golangci-lint v2.12 rejects these and silently falls back to defaults — so `make lint` was running with the **wrong** config: cyclop threshold 10 instead of the intended 15, and the test-file / main.go exclusion rules ignored entirely.

## Fix
Rewrote to the valid v2 layout: `linters.settings`, `linters.exclusions.rules` + `linters.exclusions.paths`, `default: standard`, `version: "2"` (string). `golangci-lint config verify` now passes (was 5 schema violations) and the intended thresholds/exclusions apply.

## Note
`make lint` is a **local developer tool** — CI gates on `go vet` + `gofmt`, not golangci-lint. With the config now honored, `make lint` surfaces pre-existing lint debt (~419 findings across the codebase) that the broken config had been masking. Clearing that debt is a separate, tracked effort; this PR only fixes the config so the linter reads the rules the repo intended.

No code changes; `go vet` + `gofmt` unaffected.