### PR TITLE
feat(gui): expose spot-max-price / EFA / placement-group in launch form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   us-west-2 → the correct regional list price).
 
 ### Added
+- **GUI launch form exposes the opt-in launch options.** The launch modal now
+  offers **Spot max price** ($/hr, enabled only when Spot is selected), an **EFA**
+  toggle, and a **Placement group** field — the GUI counterpart to the Phase-3a
+  CLI flags. This also fixes a latent bug: the modal's existing **Spot** toggle
+  was in form state but never sent to the daemon, so it had no effect; it (and the
+  three new fields) now thread through `SafePrismAPI.launchInstance` to the
+  `/api/v1/instances` request with the `spot`/`spot_max_price`/`efa`/
+  `placement_group` keys matching `pkg/types.LaunchRequest`. All default-off.
 - **spawn adoption — opt-in launch capabilities (Phase 3a).** Three new opt-in
   `prism workspace launch` flags, all default-off (empty/false = today's
   behavior): `--spot-max-price <$/hr>` (a real spot bid cap; requires `--spot`),

--- a/cmd/prism-gui/frontend/src/hooks/use-crud-handlers.ts
+++ b/cmd/prism-gui/frontend/src/hooks/use-crud-handlers.ts
@@ -60,6 +60,10 @@ export function useCrudHandlers(options: UseCrudHandlersOptions) {
       const result = await api.launchInstance(templateSlug, instanceName, instanceSize, isDryRun, {
         dnsName: config.dnsName,
         ttl: config.ttl,
+        spot: config.spot,
+        spotMaxPrice: config.spotMaxPrice,
+        efa: config.efa,
+        placementGroup: config.placementGroup,
       });
       // HTTP 202 approval pending (#495)
       if (result && (result as any).approval_pending) {

--- a/cmd/prism-gui/frontend/src/lib/api.launch.test.ts
+++ b/cmd/prism-gui/frontend/src/lib/api.launch.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SafePrismAPI } from './api';
+
+// Verifies the GUI launch path threads the optional launch capabilities onto the
+// wire body with the snake_case keys the daemon (pkg/types.LaunchRequest) expects.
+describe('SafePrismAPI.launchInstance wire body', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => null },
+      json: async () => ({ id: 'i-123', name: 'ws' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  function lastBody() {
+    const call = fetchMock.mock.calls.find(([url]) => String(url).includes('/api/v1/instances'));
+    expect(call, 'expected a POST to /api/v1/instances').toBeTruthy();
+    return JSON.parse((call![1] as RequestInit).body as string);
+  }
+
+  it('sends spot, spot_max_price, efa, and placement_group when set', async () => {
+    const api = new SafePrismAPI();
+    await api.launchInstance('python-ml', 'ws', 'M', false, {
+      spot: true,
+      spotMaxPrice: '0.50',
+      efa: true,
+      placementGroup: 'cluster-1',
+    });
+
+    const body = lastBody();
+    expect(body.spot).toBe(true);
+    expect(body.spot_max_price).toBe('0.50');
+    expect(body.efa).toBe(true);
+    expect(body.placement_group).toBe('cluster-1');
+  });
+
+  it('omits the optional keys when unset (opt-in, matches Go omitempty)', async () => {
+    const api = new SafePrismAPI();
+    await api.launchInstance('python-ml', 'ws', 'M');
+
+    const body = lastBody();
+    expect(body.spot).toBeUndefined();
+    expect(body.spot_max_price).toBeUndefined();
+    expect(body.efa).toBeUndefined();
+    expect(body.placement_group).toBeUndefined();
+    // core fields still present
+    expect(body.template).toBe('python-ml');
+    expect(body.name).toBe('ws');
+  });
+});

--- a/cmd/prism-gui/frontend/src/lib/api.ts
+++ b/cmd/prism-gui/frontend/src/lib/api.ts
@@ -160,7 +160,7 @@ export class SafePrismAPI {
     }
   }
 
-  async launchInstance(templateSlug: string, name: string, size: string = 'M', dryRun: boolean = false, options?: { dnsName?: string; ttl?: string }): Promise<Instance & { approval_pending?: boolean; approval_request_id?: string; message?: string }> {
+  async launchInstance(templateSlug: string, name: string, size: string = 'M', dryRun: boolean = false, options?: { dnsName?: string; ttl?: string; spot?: boolean; spotMaxPrice?: string; efa?: boolean; placementGroup?: string }): Promise<Instance & { approval_pending?: boolean; approval_request_id?: string; message?: string }> {
     const body: Record<string, unknown> = {
       template: templateSlug,
       name,
@@ -174,6 +174,19 @@ export class SafePrismAPI {
     }
     if (options?.ttl) {
       body.ttl = options.ttl;
+    }
+    // Optional launch capabilities (keys must match pkg/types.LaunchRequest json tags).
+    if (options?.spot) {
+      body.spot = true;
+    }
+    if (options?.spotMaxPrice) {
+      body.spot_max_price = options.spotMaxPrice;
+    }
+    if (options?.efa) {
+      body.efa = true;
+    }
+    if (options?.placementGroup) {
+      body.placement_group = options.placementGroup;
     }
     return this.safeRequest('/api/v1/instances', 'POST', body);
   }

--- a/cmd/prism-gui/frontend/src/modals/LaunchModal.tsx
+++ b/cmd/prism-gui/frontend/src/modals/LaunchModal.tsx
@@ -18,6 +18,9 @@ export interface LaunchConfig {
   name: string
   size: string
   spot: boolean
+  spotMaxPrice?: string
+  efa?: boolean
+  placementGroup?: string
   hibernation: boolean
   dryRun: boolean
   dnsName?: string
@@ -147,12 +150,45 @@ export function LaunchModal({ visible, selectedTemplate, onDismiss, onLaunch }: 
                 Spot instance - use lower-cost spot pricing
               </Checkbox>
               <Checkbox
+                checked={launchConfig.efa || false}
+                onChange={({ detail }) => setLaunchConfig(prev => ({ ...prev, efa: detail.checked }))}
+              >
+                EFA - attach an Elastic Fabric Adapter (MPI / tightly-coupled HPC; requires an EFA-capable instance type)
+              </Checkbox>
+              <Checkbox
                 checked={launchConfig.hibernation || false}
                 onChange={({ detail }) => setLaunchConfig(prev => ({ ...prev, hibernation: detail.checked }))}
               >
                 Hibernation - enable instance hibernation support
               </Checkbox>
             </SpaceBetween>
+          </FormField>
+
+          <FormField
+            label="Spot max price"
+            description="Optional maximum spot price in $/hr (e.g. 0.50). Leave empty for the on-demand cap. Requires the Spot instance option."
+          >
+            <Input
+              type="text"
+              value={launchConfig.spotMaxPrice ?? ''}
+              onChange={({ detail }) => setLaunchConfig(prev => ({ ...prev, spotMaxPrice: detail.value }))}
+              placeholder="on-demand cap"
+              disabled={!launchConfig.spot}
+              data-testid="launch-spot-max-price"
+            />
+          </FormField>
+
+          <FormField
+            label="Placement group"
+            description="Optional cluster placement group name for tightly-coupled / MPI workloads."
+          >
+            <Input
+              type="text"
+              value={launchConfig.placementGroup ?? ''}
+              onChange={({ detail }) => setLaunchConfig(prev => ({ ...prev, placementGroup: detail.value }))}
+              placeholder="none"
+              data-testid="launch-placement-group"
+            />
           </FormField>
 
           <FormField


### PR DESCRIPTION
## Summary

GUI counterpart to the Phase-3a CLI launch flags (`--spot-max-price` / `--efa` / `--placement-group`). The launch modal now offers a **Spot max price** input (enabled only when Spot is selected), an **EFA** toggle, and a **Placement group** field. All default-off — no behavior change unless a user opts in.

## Also fixes a latent bug
The modal's existing **Spot** toggle was in form state but **never sent to the daemon** (`use-crud-handlers` dropped it), so toggling Spot in the GUI had zero effect. It now threads through alongside the three new fields.

## Changes (3 edit sites + test)
- `src/lib/api.ts` — extend `SafePrismAPI.launchInstance` options bag; guarded snake_case body keys (`spot`/`spot_max_price`/`efa`/`placement_group`) matching `pkg/types.LaunchRequest` json tags (omit when unset, mirroring Go `omitempty`).
- `src/modals/LaunchModal.tsx` — extend `LaunchConfig`; add the three controls (spot-max-price `Input` disabled unless Spot on, EFA `Checkbox`, placement-group `Input`), with `data-testid`s.
- `src/hooks/use-crud-handlers.ts` — forward `spot` + the three new fields into the API call.
- `src/lib/api.launch.test.ts` — Vitest test asserting the POST body carries the keys when set and omits them when unset.

## Wire contract
The GUI POSTs directly to the daemon; there's no shared TS type, so the snake_case keys are hand-written to match `pkg/types/requests.go`. Backend + CLI already ship these fields (merged in #666).

## Gates
`npm run build` ✓, `npm run typecheck` ✓, `npm run test:unit` ✓ (288 tests). eslint: adds no new errors; the one changed `max-lines-per-function` warning on `LaunchModal` is a pre-existing over-length function (131→162 lines) — eslint isn't a CI gate and the file was already non-compliant.

## Not included
`QuickStartWizard` (no advanced options) and `service.go` (stripped LaunchRequest, not in this HTTP path) are unchanged. E2E page-object helpers for the new fields deferred (unit test covers the wire contract).