### PR TITLE
fix(security): resolve 15 Semgrep SAST findings blocking main's Security Scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Green the Semgrep SAST scan (15 blocking findings on `main`).** The Security
+  Scan workflow runs Semgrep full-repo on push to `main` and had been red on 15
+  findings (PR scans are diff-aware, so they passed). Root cause for most: prior
+  triage used `//nolint:...,semgrep` comments, which Semgrep does not read — it
+  honors `// nosemgrep: <rule-id>`. Resolved all 15 with real fixes where
+  warranted and justified suppressions otherwise:
+  - **Fixes:** added `MinVersion: tls.VersionTLS12` to the reverse-proxy TLS
+    configs (`pkg/web/proxy.go`); replaced the terminal WebSocket's
+    always-true `CheckOrigin` with a real same-origin/loopback check
+    (`sameOriginCheck`, `pkg/web/terminal.go`) to close a cross-site WebSocket
+    hijacking (CSRF) gap; bound the desktop GUI's local terminal bridge to
+    `127.0.0.1:8948` instead of all interfaces (`cmd/prism-gui/main.go`).
+  - **Justified (`// nosemgrep` with rationale):** SSH `InsecureIgnoreHostKey`
+    TOFU fallbacks (host key recorded + verified on subsequent connects), `math/rand`
+    used for retry jitter (not crypto), `filepath.Clean` (traversal enforced by an
+    `IsAbs` + validator check, #598), an `fmt.Sprintf` HTTP error string
+    mis-flagged as SQL injection, a placeholder cert-pin fingerprint mis-flagged
+    as a secret, MD5 used to verify S3 ETags (not a signature), `ReverseProxy.Director`
+    (drops no headers), and `InsecureSkipVerify` for self-signed EC2 instance
+    certs (#596). Establishes the `nosemgrep` convention for the repo.
+
 ### Fixed
 - **`.golangci.yml` migrated to the golangci-lint v2 schema.** The config
   declared `version: 2` but used v1-schema keys (`linters-settings`,

--- a/cmd/prism-gui/main.go
+++ b/cmd/prism-gui/main.go
@@ -222,8 +222,12 @@ func main() {
 			}
 		})
 
-		log.Println("🔌 Starting WebSocket server on :8948")
-		if err := http.ListenAndServe(":8948", mux); err != nil {
+		log.Println("🔌 Starting WebSocket server on 127.0.0.1:8948")
+		// Bind loopback only: this is a local IPC bridge between the desktop GUI
+		// and its own process, never exposed off-host. TLS is unwarranted for a
+		// localhost socket.
+		// nosemgrep: go.lang.security.audit.net.use-tls.use-tls -- localhost-only desktop IPC bridge; not network-exposed.
+		if err := http.ListenAndServe("127.0.0.1:8948", mux); err != nil {
 			log.Printf("❌ WebSocket server error: %v", err)
 		}
 	}()

--- a/cmd/prism-gui/terminal_handler.go
+++ b/cmd/prism-gui/terminal_handler.go
@@ -379,7 +379,8 @@ func (ts *TerminalSession) cleanup() {
 func buildTOFUHostKeyCallback(knownHostsPath string) ssh.HostKeyCallback {
 	if err := os.MkdirAll(filepath.Dir(knownHostsPath), 0700); err != nil {
 		log.Printf("[WARNING] buildTOFUHostKeyCallback: cannot create known_hosts dir: %v", err)
-		return ssh.InsecureIgnoreHostKey() //nolint:gosec,semgrep // intentional TOFU fallback; host key verified on subsequent connections
+		// nosemgrep: go.lang.security.audit.crypto.insecure_ssh.avoid-ssh-insecure-ignore-host-key -- intentional TOFU fallback on setup error; host key is recorded and verified on subsequent connections.
+		return ssh.InsecureIgnoreHostKey() //nolint:gosec // intentional TOFU fallback; host key verified on subsequent connections
 	}
 	// Create file if it does not exist.
 	if f, err := os.OpenFile(knownHostsPath, os.O_CREATE|os.O_RDONLY, 0600); err == nil {
@@ -388,7 +389,8 @@ func buildTOFUHostKeyCallback(knownHostsPath string) ssh.HostKeyCallback {
 	checker, err := knownhosts.New(knownHostsPath)
 	if err != nil {
 		log.Printf("[WARNING] buildTOFUHostKeyCallback: cannot load known_hosts: %v", err)
-		return ssh.InsecureIgnoreHostKey() //nolint:gosec,semgrep // intentional TOFU fallback; host key verified on subsequent connections
+		// nosemgrep: go.lang.security.audit.crypto.insecure_ssh.avoid-ssh-insecure-ignore-host-key -- intentional TOFU fallback on setup error; host key is recorded and verified on subsequent connections.
+		return ssh.InsecureIgnoreHostKey() //nolint:gosec // intentional TOFU fallback; host key verified on subsequent connections
 	}
 	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		verifyErr := checker(hostname, remote, key)

--- a/pkg/aws/retry.go
+++ b/pkg/aws/retry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- retry jitter, not cryptography.
 	"math/rand" //nolint:gosec // math/rand used for retry jitter, not cryptography
 	"net"
 	"strings"

--- a/pkg/daemon/connection_proxy_handlers.go
+++ b/pkg/daemon/connection_proxy_handlers.go
@@ -228,7 +228,8 @@ func (s *Server) setupHostKeyVerification(wsConn *websocket.Conn, publicIP strin
 		hostKeyCallback, err := loadKnownHosts(knownHostsPath)
 		if err != nil {
 			_ = wsConn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("Warning: Failed to load known hosts, using insecure mode: %v\r\n", err)))
-			return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec,semgrep // intentional TOFU fallback; host key verified on subsequent connections
+			// nosemgrep: go.lang.security.audit.crypto.insecure_ssh.avoid-ssh-insecure-ignore-host-key -- intentional TOFU fallback; host key verified on subsequent connections.
+			return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec // intentional TOFU fallback; host key verified on subsequent connections
 		}
 		return hostKeyCallback, nil
 	}
@@ -236,7 +237,8 @@ func (s *Server) setupHostKeyVerification(wsConn *websocket.Conn, publicIP strin
 	// Create known hosts file if it doesn't exist
 	if err := os.MkdirAll(filepath.Dir(knownHostsPath), 0700); err != nil {
 		_ = wsConn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("Warning: Failed to create known hosts directory, using insecure mode: %v\r\n", err)))
-		return ssh.InsecureIgnoreHostKey(), nil
+		// nosemgrep: go.lang.security.audit.crypto.insecure_ssh.avoid-ssh-insecure-ignore-host-key -- intentional TOFU fallback when known_hosts dir can't be created; host key verified on subsequent connections.
+		return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec // intentional TOFU fallback; host key verified on subsequent connections
 	}
 
 	// Use trust-on-first-use

--- a/pkg/daemon/file_ops_handlers.go
+++ b/pkg/daemon/file_ops_handlers.go
@@ -69,7 +69,8 @@ func (s *Server) handleListInstanceFiles(w http.ResponseWriter, r *http.Request,
 		remotePath = "/home"
 	}
 	// Normalize and validate path (#598)
-	remotePath = filepath.Clean(remotePath) //nolint:semgrep // path traversal is prevented by the IsAbs check below and validateRemotePath (#598)
+	// nosemgrep: go.lang.security.filepath-clean-misuse.filepath-clean-misuse -- not used as the traversal defense; the IsAbs check below and validateRemotePath (#598) enforce that.
+	remotePath = filepath.Clean(remotePath)
 	if !filepath.IsAbs(remotePath) {
 		s.writeError(w, http.StatusBadRequest, "Path must be absolute")
 		return

--- a/pkg/daemon/marketplace_handlers.go
+++ b/pkg/daemon/marketplace_handlers.go
@@ -314,7 +314,8 @@ func (s *Server) handleMarketplaceUpdate(w http.ResponseWriter, r *http.Request)
 
 	// Update template using marketplace registry
 	if err := s.marketplaceRegistry.UpdateTemplate(templateID, &update); err != nil {
-		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("update failed: %v", err)) //nolint:semgrep // err is internal, not user-controlled SQL; false positive
+		// nosemgrep: go.lang.security.injection.tainted-sql-string.tainted-sql-string -- fmt.Sprintf builds an HTTP error string, not SQL; err is internal. False positive.
+		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("update failed: %v", err))
 		return
 	}
 

--- a/pkg/profile/security/registry_secure.go
+++ b/pkg/profile/security/registry_secure.go
@@ -135,7 +135,8 @@ func NewCertificatePinner() (*CertificatePinner, error) {
 	// Load pinned certificate fingerprints from config or use defaults
 	pinnedFingerprints := []string{
 		// AWS S3 certificate fingerprints (these would be real in production)
-		"sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", //nolint:semgrep // placeholder fingerprint, not a real secret
+		// nosemgrep: generic.secrets.security.detected-telegram-bot-api-key.detected-telegram-bot-api-key -- placeholder cert-pin fingerprint (all-A's), not a real secret.
+		"sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 		"sha256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=", // Backup cert
 	}
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- retry jitter, not cryptography.
 	"math/rand" //nolint:gosec // math/rand used for retry jitter, not cryptography
 	"strings"
 	"time"

--- a/pkg/storage/s3_transfer.go
+++ b/pkg/storage/s3_transfer.go
@@ -602,6 +602,7 @@ func computeFileMD5(filePath string) (string, error) {
 	}
 	defer file.Close()
 
+	// nosemgrep: go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5 -- S3 defines ETag as the MD5 of the object; this verifies against that ETag, not a security signature.
 	hash := md5.New()
 	if _, err := io.Copy(hash, file); err != nil {
 		return "", err

--- a/pkg/web/proxy.go
+++ b/pkg/web/proxy.go
@@ -63,8 +63,11 @@ func (pm *ProxyManager) RegisterInstance(instance *types.Instance) error {
 		return fmt.Errorf("invalid target URL: %w", err)
 	}
 
-	// Create reverse proxy with custom director
+	// Create reverse proxy with custom director. Director sets scheme/host +
+	// forwarding headers explicitly and drops none, so the Rewrite-vs-Director
+	// header-stripping concern the linter guards against does not apply here.
 	proxy := &httputil.ReverseProxy{
+		// nosemgrep: go.lang.security.reverseproxy-director.reverseproxy-director -- Director drops no caller headers; see comment above.
 		Director: func(req *http.Request) {
 			req.URL.Scheme = targetURL.Scheme
 			req.URL.Host = targetURL.Host
@@ -88,8 +91,12 @@ func (pm *ProxyManager) RegisterInstance(instance *types.Instance) error {
 		},
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // Allow self-signed certificates on EC2 instances (#596)
-				// TODO: Add instance CA to custom cert pool instead of disabling verification
+				MinVersion: tls.VersionTLS12,
+				// nosemgrep: go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion -- MinVersion is set above (TLS 1.2).
+				// InsecureSkipVerify is intentional: the proxy connects to self-signed certs on
+				// ephemeral EC2 instances (#596). TODO: add the instance CA to a custom cert pool
+				// instead of disabling verification.
+				InsecureSkipVerify: true, //nolint:gosec // self-signed EC2 instance certs (#596)
 			},
 			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
@@ -295,7 +302,9 @@ func (wp *WebSocketProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	dialer := websocket.Dialer{
 		HandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+		// nosemgrep: go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion -- MinVersion set to TLS 1.2.
+		// InsecureSkipVerify is intentional: self-signed certs on ephemeral EC2 instances (#596).
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}, //nolint:gosec // self-signed EC2 instance certs (#596)
 	}
 
 	backendConn, resp, err := dialer.Dial(backendURL+r.URL.Path, nil)

--- a/pkg/web/terminal.go
+++ b/pkg/web/terminal.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os/exec"
 
 	"github.com/gorilla/websocket"
@@ -60,6 +62,37 @@ type OutputData struct {
 	Data string `json:"data"`
 }
 
+// sameOriginCheck is the WebSocket upgrader's origin guard. It accepts requests
+// with no Origin header (non-browser clients such as the CLI/desktop app, which
+// don't set one) and requests whose Origin host matches the request Host or is
+// loopback. Cross-site origins are rejected to prevent cross-site WebSocket
+// hijacking (CSRF) — a browser page on another site cannot open this socket.
+func sameOriginCheck(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// No Origin: not a browser-initiated cross-site request (CLI/native client).
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	originHost := hostOnly(u.Host)
+	if originHost == hostOnly(r.Host) {
+		return true
+	}
+	// Allow loopback origins — the terminal server is fronted locally.
+	return originHost == "localhost" || originHost == "127.0.0.1" || originHost == "::1"
+}
+
+// hostOnly strips any :port from a host[:port] string.
+func hostOnly(hostport string) string {
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		return h
+	}
+	return hostport
+}
+
 // NewTerminalServer creates a new terminal server
 func NewTerminalServer(sshConfig *ssh.ClientConfig) *TerminalServer {
 	return &TerminalServer{
@@ -68,16 +101,18 @@ func NewTerminalServer(sshConfig *ssh.ClientConfig) *TerminalServer {
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  32 * 1024,
 			WriteBufferSize: 32 * 1024,
-			CheckOrigin: func(r *http.Request) bool {
-				return true // Allow all origins for terminal access
-			},
+			// Guard against cross-site WebSocket hijacking (CSRF): only accept
+			// same-origin handshakes, or non-browser clients that send no Origin.
+			CheckOrigin: sameOriginCheck,
 		},
 	}
 }
 
 // ServeHTTP handles terminal WebSocket connections
 func (ts *TerminalServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Upgrade HTTP connection to WebSocket
+	// Upgrade HTTP connection to WebSocket. Origin is validated by the upgrader's
+	// sameOriginCheck (set in NewTerminalServer) — this is not an unguarded upgrade.
+	// nosemgrep: go.gorilla.security.audit.websocket-missing-origin-check.websocket-missing-origin-check -- CheckOrigin=sameOriginCheck enforces same-origin/loopback; the rule can't see the non-literal CheckOrigin.
 	conn, err := ts.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("WebSocket upgrade failed: %v", err), http.StatusInternalServerError)

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -51,6 +51,33 @@ func newDashboard() *DashboardServer {
 
 // ── DashboardServer ───────────────────────────────────────────────────────
 
+func TestSameOriginCheck(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		origin string
+		want   bool
+	}{
+		{"no origin (CLI/native client)", "example.com", "", true},
+		{"same origin", "app.example.com", "http://app.example.com", true},
+		{"same origin with port", "app.example.com:8947", "http://app.example.com:8947", true},
+		{"loopback origin", "app.example.com", "http://localhost:3000", true},
+		{"127.0.0.1 origin", "app.example.com", "http://127.0.0.1:5173", true},
+		{"cross-site origin rejected", "app.example.com", "http://evil.example.net", false},
+		{"malformed origin rejected", "app.example.com", "://not a url", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "http://"+tt.host+"/terminal", nil)
+			r.Host = tt.host
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			assert.Equal(t, tt.want, sameOriginCheck(r))
+		})
+	}
+}
+
 func TestDashboardServer_Dashboard(t *testing.T) {
 	srv := httptest.NewServer(newDashboard())
 	defer srv.Close()


### PR DESCRIPTION
## Summary

The **Security Scan** workflow (`security.yml`) runs Semgrep **full-repo on push to `main`** and has been **red for 15+ consecutive runs** — going back well before recent work (fails on `1b5d19d92`, `7bb2b6621`, …). It's a long-standing pre-existing failure, not a regression. PR checks passed because Semgrep is diff-aware on PRs; the push-to-main scan surfaces the whole backlog.

**Root cause for most findings:** prior triage used `//nolint:...,semgrep` comments — but Semgrep doesn't read `//nolint` (that's gosec/golangci syntax). It honors `// nosemgrep: <rule-id>`.

## Resolution (fix real issues, justify the rest) — all 15

**Real fixes:**
- `pkg/web/proxy.go` — add `MinVersion: tls.VersionTLS12` to both reverse-proxy TLS configs (`missing-ssl-minversion`).
- `pkg/web/terminal.go` — replace the always-`true` WebSocket `CheckOrigin` with a real same-origin/loopback guard (`sameOriginCheck`), closing a cross-site WebSocket hijacking (CSRF) gap. New `TestSameOriginCheck` (7 cases).
- `cmd/prism-gui/main.go` — bind the local terminal bridge to `127.0.0.1:8948` (was all interfaces).

**Justified suppressions** (`// nosemgrep: <rule> -- <reason>`, confirmed false-positive / accepted): SSH `InsecureIgnoreHostKey` TOFU fallbacks ×3, `math/rand` retry jitter ×2, `filepath.Clean` (traversal enforced by IsAbs + validator, #598), `fmt.Sprintf` HTTP-error mis-flagged as SQL injection, placeholder cert-pin fingerprint mis-flagged as a secret, MD5 for S3 ETag verification, `ReverseProxy.Director` (drops no headers), `InsecureSkipVerify` for self-signed EC2 certs (#596). Establishes the repo's `nosemgrep` convention (none existed before).

## Verification
- Local `semgrep scan --config p/golang --config p/secrets --error` → **0 findings** (matches CI config).
- `go build/vet/test ./...` green; `cmd/prism-gui` module vets clean; govulncheck clean; gofmt clean.

After merge, the Security Scan workflow should go green on `main` for the first time in weeks.