### PR TITLE
feat(gui): expose completion-signaling options in launch form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **GUI launch form exposes the completion-signaling options.** The launch modal
+  now offers an **On completion** dropdown (None / terminate / stop / hibernate)
+  plus **Completion file** and **Completion delay** inputs (enabled only when an
+  action is chosen) — the GUI counterpart to the Phase-3b CLI flags. They thread
+  through `SafePrismAPI.launchInstance` to the `/api/v1/instances` request with the
+  `on_complete`/`completion_file`/`completion_delay` keys matching
+  `pkg/types.LaunchRequest`. All default-off; the GUI launch surface is now at
+  parity with the CLI.
 - **Completion signaling: `--on-complete` / `--completion-file` / `--completion-delay`
   launch flags (spawn adoption Phase 3b).** Opt-in, default-off: run a batch job and
   have the on-instance agent (spored) auto **terminate / stop / hibernate** the

--- a/cmd/prism-gui/frontend/src/hooks/use-crud-handlers.ts
+++ b/cmd/prism-gui/frontend/src/hooks/use-crud-handlers.ts
@@ -64,6 +64,9 @@ export function useCrudHandlers(options: UseCrudHandlersOptions) {
         spotMaxPrice: config.spotMaxPrice,
         efa: config.efa,
         placementGroup: config.placementGroup,
+        onComplete: config.onComplete,
+        completionFile: config.completionFile,
+        completionDelay: config.completionDelay,
       });
       // HTTP 202 approval pending (#495)
       if (result && (result as any).approval_pending) {

--- a/cmd/prism-gui/frontend/src/lib/api.launch.test.ts
+++ b/cmd/prism-gui/frontend/src/lib/api.launch.test.ts
@@ -39,6 +39,20 @@ describe('SafePrismAPI.launchInstance wire body', () => {
     expect(body.placement_group).toBe('cluster-1');
   });
 
+  it('sends on_complete, completion_file, and completion_delay when set', async () => {
+    const api = new SafePrismAPI();
+    await api.launchInstance('python-ml', 'ws', 'M', false, {
+      onComplete: 'terminate',
+      completionFile: '/tmp/done',
+      completionDelay: '1m',
+    });
+
+    const body = lastBody();
+    expect(body.on_complete).toBe('terminate');
+    expect(body.completion_file).toBe('/tmp/done');
+    expect(body.completion_delay).toBe('1m');
+  });
+
   it('omits the optional keys when unset (opt-in, matches Go omitempty)', async () => {
     const api = new SafePrismAPI();
     await api.launchInstance('python-ml', 'ws', 'M');
@@ -48,6 +62,9 @@ describe('SafePrismAPI.launchInstance wire body', () => {
     expect(body.spot_max_price).toBeUndefined();
     expect(body.efa).toBeUndefined();
     expect(body.placement_group).toBeUndefined();
+    expect(body.on_complete).toBeUndefined();
+    expect(body.completion_file).toBeUndefined();
+    expect(body.completion_delay).toBeUndefined();
     // core fields still present
     expect(body.template).toBe('python-ml');
     expect(body.name).toBe('ws');

--- a/cmd/prism-gui/frontend/src/lib/api.ts
+++ b/cmd/prism-gui/frontend/src/lib/api.ts
@@ -160,7 +160,7 @@ export class SafePrismAPI {
     }
   }
 
-  async launchInstance(templateSlug: string, name: string, size: string = 'M', dryRun: boolean = false, options?: { dnsName?: string; ttl?: string; spot?: boolean; spotMaxPrice?: string; efa?: boolean; placementGroup?: string }): Promise<Instance & { approval_pending?: boolean; approval_request_id?: string; message?: string }> {
+  async launchInstance(templateSlug: string, name: string, size: string = 'M', dryRun: boolean = false, options?: { dnsName?: string; ttl?: string; spot?: boolean; spotMaxPrice?: string; efa?: boolean; placementGroup?: string; onComplete?: string; completionFile?: string; completionDelay?: string }): Promise<Instance & { approval_pending?: boolean; approval_request_id?: string; message?: string }> {
     const body: Record<string, unknown> = {
       template: templateSlug,
       name,
@@ -187,6 +187,16 @@ export class SafePrismAPI {
     }
     if (options?.placementGroup) {
       body.placement_group = options.placementGroup;
+    }
+    // Completion signaling (Phase 3b): spored auto terminate/stop/hibernate on completion.
+    if (options?.onComplete) {
+      body.on_complete = options.onComplete;
+    }
+    if (options?.completionFile) {
+      body.completion_file = options.completionFile;
+    }
+    if (options?.completionDelay) {
+      body.completion_delay = options.completionDelay;
     }
     return this.safeRequest('/api/v1/instances', 'POST', body);
   }

--- a/cmd/prism-gui/frontend/src/modals/LaunchModal.tsx
+++ b/cmd/prism-gui/frontend/src/modals/LaunchModal.tsx
@@ -14,6 +14,77 @@ import {
 import { Template } from '../lib/types'
 import { getTemplateName, getTemplateDescription } from '../lib/template-utils'
 
+// onCompleteLabel maps an on-complete action value to its dropdown label.
+function onCompleteLabel(v?: string): string {
+  switch (v) {
+    case 'terminate':
+      return 'Terminate'
+    case 'stop':
+      return 'Stop'
+    case 'hibernate':
+      return 'Hibernate'
+    default:
+      return 'None (stay running)'
+  }
+}
+
+// CompletionOptions renders the completion-signaling controls (Phase 3b): spored
+// auto terminate/stop/hibernate the workspace when the completion file appears.
+// Extracted from LaunchModal to keep that component's complexity in check.
+function CompletionOptions({ config, setConfig }: {
+  config: LaunchConfig
+  setConfig: React.Dispatch<React.SetStateAction<LaunchConfig>>
+}) {
+  return (
+    <>
+      <FormField
+        label="On completion"
+        description="Auto-terminate/stop/hibernate the workspace when the job signals completion (writes the completion file)."
+      >
+        <Select
+          selectedOption={{ value: config.onComplete ?? '', label: onCompleteLabel(config.onComplete) }}
+          onChange={({ detail }) => setConfig(prev => ({ ...prev, onComplete: detail.selectedOption.value || undefined }))}
+          options={[
+            { value: '', label: 'None (stay running)' },
+            { value: 'terminate', label: 'Terminate' },
+            { value: 'stop', label: 'Stop' },
+            { value: 'hibernate', label: 'Hibernate' },
+          ]}
+          data-testid="launch-on-complete"
+        />
+      </FormField>
+
+      <FormField
+        label="Completion file"
+        description="File spored watches to trigger the on-completion action (default /tmp/SPAWN_COMPLETE). Requires an on-completion action."
+      >
+        <Input
+          type="text"
+          value={config.completionFile ?? ''}
+          onChange={({ detail }) => setConfig(prev => ({ ...prev, completionFile: detail.value }))}
+          placeholder="/tmp/SPAWN_COMPLETE"
+          disabled={!config.onComplete}
+          data-testid="launch-completion-file"
+        />
+      </FormField>
+
+      <FormField
+        label="Completion delay"
+        description="Grace period before the on-completion action (e.g. 30s). Requires an on-completion action."
+      >
+        <Input
+          type="text"
+          value={config.completionDelay ?? ''}
+          onChange={({ detail }) => setConfig(prev => ({ ...prev, completionDelay: detail.value }))}
+          placeholder="30s"
+          disabled={!config.onComplete}
+          data-testid="launch-completion-delay"
+        />
+      </FormField>
+    </>
+  )
+}
+
 export interface LaunchConfig {
   name: string
   size: string
@@ -25,6 +96,9 @@ export interface LaunchConfig {
   dryRun: boolean
   dnsName?: string
   ttl?: string
+  onComplete?: string
+  completionFile?: string
+  completionDelay?: string
 }
 
 export interface LaunchModalProps {
@@ -190,6 +264,8 @@ export function LaunchModal({ visible, selectedTemplate, onDismiss, onLaunch }: 
               data-testid="launch-placement-group"
             />
           </FormField>
+
+          <CompletionOptions config={launchConfig} setConfig={setLaunchConfig} />
 
           <FormField
             label="Validation"


### PR DESCRIPTION
## Summary

GUI counterpart to the Phase-3b CLI flags (#672). Brings the GUI launch surface to **parity with the CLI** — it now exposes completion signaling: run a batch job and have spored auto **terminate/stop/hibernate** the workspace when it finishes.

New controls in the launch modal:
- **On completion** — a dropdown: None (default) / terminate / stop / hibernate.
- **Completion file** — text input, default `/tmp/SPAWN_COMPLETE`, enabled only when an action is chosen.
- **Completion delay** — text input (e.g. `30s`), enabled only when an action is chosen.

## Changes (3 edit sites + test)
- `src/lib/api.ts` — extend `SafePrismAPI.launchInstance` options bag; guarded `on_complete`/`completion_file`/`completion_delay` body keys matching `pkg/types.LaunchRequest` json tags (omit when unset).
- `src/modals/LaunchModal.tsx` — extend `LaunchConfig`; new **`CompletionOptions` sub-component** (extracted to keep `LaunchModal` under the eslint complexity threshold — the three added controls would otherwise tip it to 18 > 15) with the Select + two conditionally-disabled Inputs and `data-testid`s.
- `src/hooks/use-crud-handlers.ts` — forward the three fields.
- `src/lib/api.launch.test.ts` — assert the keys reach the POST body when set, omitted when unset.

## Wire contract
GUI POSTs directly to the daemon; no shared TS type, so snake_case keys are hand-matched to `pkg/types/requests.go`. Backend + CLI already ship these (#672).

## Gates
`npm run build` ✓, `npm run typecheck` ✓, `npm run test:unit` ✓ (289 tests). **Lint-neutral** — 0 new violations vs main (the completion section was extracted into `CompletionOptions` specifically to avoid adding a new `complexity` error to `LaunchModal`).

## Not included
`QuickStartWizard` (no advanced options) and `service.go` (stripped LaunchRequest, not in this HTTP path) unchanged. E2E page-object helpers deferred (unit test covers the wire contract), consistent with #669.