### PR TITLE
docs: correctness pass — IAM policy, command drift, versions, nav, domain (Phase 2)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Prism v0.5.4 Installation Guide
+# Prism Installation Guide
 
 ## Quick Start (Package Managers - Recommended)
 
@@ -51,15 +51,15 @@ make install
 ## First Launch
 
 ```bash
-# Start the daemon
-prism daemon start
-
-# Launch your first workstation
-prism launch "Python Machine Learning (Simplified)" my-research
+# Launch your first workstation (the daemon auto-starts on first use)
+prism workspace launch "Python Machine Learning (Simplified)" my-research
 
 # Connect to your workstation
-prism connect my-research
+prism workspace connect my-research
 ```
+
+> The daemon starts automatically when you run any command. To manage it
+> explicitly, use `prism admin daemon status|start|stop`.
 
 ## Platform-Specific Notes
 
@@ -83,15 +83,24 @@ prism connect my-research
 ### Development Mode (Optional)
 To avoid keychain password prompts during development:
 ```bash
-export CLOUDWORKSTATION_DEV=true
+export PRISM_DEV=true
 # Or add to ~/.bashrc or ~/.zshrc
 ```
 
 ### AWS Credentials
 
-Prism requires AWS credentials to launch cloud workstations. See the **[AWS Setup Guide](AWS_SETUP_GUIDE.md)** for complete configuration instructions.
+Prism requires AWS credentials to launch cloud workstations. See the **[AWS Setup Guide](docs/user-guides/AWS_SETUP_GUIDE.md)** for complete configuration instructions and the IAM permissions Prism needs.
 
-**Quick setup:**
+**Quick setup (browser login, recommended — AWS CLI v2.32+):**
+```bash
+# Authenticate via your browser (IAM Identity Center / federated identity)
+aws login
+
+# Verify
+aws sts get-caller-identity
+```
+
+**Alternative — long-term access keys:**
 ```bash
 # Configure with your preferred AWS profile name
 aws configure --profile aws  # or any name you prefer
@@ -104,7 +113,7 @@ export AWS_REGION=us-west-2
 echo 'export AWS_PROFILE=aws' >> ~/.zshrc
 ```
 
-**Need help?** The [AWS Setup Guide](AWS_SETUP_GUIDE.md) covers:
+**Need help?** The [AWS Setup Guide](docs/user-guides/AWS_SETUP_GUIDE.md) covers:
 - AWS account setup and permissions
 - Using non-default profiles (like 'aws' instead of 'default')
 - Regional configuration
@@ -152,7 +161,7 @@ scoop bucket rm scttfrdmn
 ### Manual
 ```bash
 # Remove binaries
-sudo rm -f /usr/local/bin/cws /usr/local/bin/prismd /usr/local/bin/prism-gui
+sudo rm -f /usr/local/bin/prism /usr/local/bin/prismd /usr/local/bin/prism-gui
 
 # Remove configuration (optional)
 rm -rf ~/.prism
@@ -164,19 +173,14 @@ rm -rf ~/.prism
 
 **Daemon won't start:**
 ```bash
-prism daemon stop
-prism daemon start
-```
-
-**Keychain password prompts:**
-```bash
-export CLOUDWORKSTATION_DEV=true
+prism admin daemon stop
+prism admin daemon start
 ```
 
 **AWS permission errors:**
 ```bash
 aws sts get-caller-identity
-prism doctor
+prism admin daemon status
 ```
 
-For more help, see the [Troubleshooting Guide](https://github.com/scttfrdmn/prism/blob/main/TROUBLESHOOTING.md).
+For more help, see the [Troubleshooting Guide](docs/user-guides/TROUBLESHOOTING.md).

--- a/README.md
+++ b/README.md
@@ -51,34 +51,24 @@ Prism provides researchers with **pre-configured cloud workstations** for data a
 brew install scttfrdmn/tap/prism
 ```
 
-**Manual Installation**
-```bash
-# Download and extract
-curl -L https://github.com/scttfrdmn/prism/releases/latest/download/prism_0.5.11_darwin_arm64.tar.gz | tar xz
+**Desktop app (GUI)**
 
-# Install binaries
-sudo mv prism prismd /usr/local/bin/
-```
+Download the latest `.dmg` (macOS) or `.msi` (Windows) from the
+[releases page](https://github.com/scttfrdmn/prism/releases/latest).
 
 ### Linux
 
-**Debian/Ubuntu**
+Download the latest release archive from the
+[releases page](https://github.com/scttfrdmn/prism/releases/latest), extract, and
+move the binaries onto your `PATH`:
+
 ```bash
-wget https://github.com/scttfrdmn/prism/releases/download/v0.5.11/prism_0.5.11_linux_amd64.deb
-sudo dpkg -i prism_0.5.11_linux_amd64.deb
+# Replace the URL with the asset for your platform from the releases page
+tar xz -f prism_<version>_linux_amd64.tar.gz
+sudo mv prism prismd /usr/local/bin/
 ```
 
-**RHEL/CentOS/Fedora**
-```bash
-wget https://github.com/scttfrdmn/prism/releases/download/v0.5.11/prism_0.5.11_linux_amd64.rpm
-sudo rpm -i prism_0.5.11_linux_amd64.rpm
-```
-
-**Alpine Linux**
-```bash
-wget https://github.com/scttfrdmn/prism/releases/download/v0.5.11/prism_0.5.11_linux_amd64.apk
-sudo apk add --allow-untrusted prism_0.5.11_linux_amd64.apk
-```
+Or build from source (see [Build from Source](#build-from-source) below).
 
 ### Windows
 
@@ -129,13 +119,13 @@ For experienced users or automation:
 prism templates
 
 # Launch a Python ML environment
-prism launch python-ml my-research
+prism workspace launch python-ml my-research
 
 # Connect via SSH
-prism connect my-research
+prism workspace connect my-research
 
 # View running workspaces
-prism list
+prism workspace list
 ```
 
 **Automatic Features:**
@@ -195,10 +185,10 @@ prism list
 prism templates
 
 # Launch a base OS template
-prism launch ubuntu-24-04-x86 my-instance
+prism workspace launch ubuntu-24-04-x86 my-instance
 
 # Launch a community template with applications
-prism launch python-ml my-ml-project
+prism workspace launch python-ml my-ml-project
 
 # Get detailed template info
 prism templates info python-ml
@@ -211,23 +201,23 @@ prism templates info python-ml
 ### Basic Workspace Management
 ```bash
 # Launch a workspace
-prism launch python-ml my-project
+prism workspace launch python-ml my-project
 
 # List running workspaces
-prism list
+prism workspace list
 
 # Connect via SSH
-prism connect my-project
+prism workspace connect my-project
 
 # Stop workspace
-prism stop my-project
+prism workspace stop my-project
 ```
 
 ### Cost Optimization
 ```bash
 # Hibernate to preserve state while saving costs
-prism hibernate my-workspace
-prism resume my-workspace
+prism workspace hibernate my-workspace
+prism workspace resume my-workspace
 
 # Automated idle policies
 prism idle profile list
@@ -243,7 +233,7 @@ prism project create ml-research --budget 500
 prism project member add ml-research user@example.com --role member
 
 # Launch workspace in project
-prism launch python-ml analysis --project ml-research
+prism workspace launch python-ml analysis --project ml-research
 ```
 
 ### Multi-Modal Access
@@ -263,7 +253,7 @@ curl http://localhost:8947/api/v1/instances
 prism --help                      # Show all commands
 prism templates                   # List available templates
 prism templates info <template>   # Detailed template info
-prism doctor                      # System health check
+prism admin daemon status         # Daemon / system health check
 ```
 
 **Guides:**
@@ -276,73 +266,13 @@ prism doctor                      # System health check
 - [Budget System Philosophy](docs/BUDGET_PHILOSOPHY.md) - Multi-budget system design and conceptual model (v0.5.10+)
 - [Budget Banking Philosophy](docs/BUDGET_BANKING_PHILOSOPHY.md) - Surplus tracking and burst budgeting
 - [Resource Tagging](docs/RESOURCE_TAGGING.md) - Cost optimization and zombie resource cleanup
-- [Security & Compliance](docs/admin-guides/SECURITY_COMPLIANCE_ROADMAP.md) - NIST 800-171, HIPAA, GDPR, FISMA compliance
+- [Compliance Matrix](docs/admin-guides/COMPLIANCE_MATRIX.md) - NIST 800-171, HIPAA, and framework support
 - [Changelog](CHANGELOG.md) - Version history and release notes
 
 ## 🗓️ Version History
 
-### v0.5.11 (Current) - Complete User Invitation & Collaboration System
-- **User Invitation System**: Individual, bulk, and shared token invitations with full lifecycle management
-- **Automatic Provisioning**: Research users created with SSH keys, UID/GID, and EFS home directories on invitation acceptance
-- **Quota Validation**: Pre-flight AWS capacity checking prevents bulk invitation failures
-- **Professional GUI**: Cloudscape-based invitation management interface with QR code generation
-- **Zero Manual Setup**: End-to-end automation from invitation send to workspace access
-
-### v0.5.10 - Multi-Project Budget System & Rebranding
-- **Multi-Project Budgets**: Projects can reference multiple budgets for complex funding scenarios
-- **Budget Surplus Banking**: Track and leverage surplus funds for burst research needs
-- **Budget Performance Metrics**: ROI analysis, utilization tracking, and forecasting
-- **Complete Prism Rebrand**: CloudWorkStation → Prism across entire codebase (29,225 files)
-- **Binary Rename**: `cws`/`prismd` → `prism`/`prismd`
-
-### v0.5.9 - Navigation Restructure & UX Polish
-- **Streamlined Navigation**: 14 → 6 top-level menu items for clearer workspace focus
-- **Unified Storage**: Single storage interface combining EFS and EBS management
-- **Hierarchical Settings**: Advanced features organized under collapsible settings
-- **Terminal/WebView Integration**: Merged into workspaces view for better context
-
-### v0.5.8 - Quick Start Experience & Reliability
-- **Quick Start Wizard**: Launch first workspace in 30 seconds with GUI wizard
-- **CLI Init Command**: Interactive `prism init` onboarding in terminal
-- **Workspace Terminology**: Consistent "workspace" naming across all interfaces
-- **Background State Monitoring**: Async daemon monitoring of AWS state changes
-- **Billing Accuracy**: Correct hibernation billing exception handling
-- **Reliability Improvements**: AWS system status checks, IAM eventual consistency
-
-### v0.5.7 - Template File Provisioning & Test Infrastructure
-- **Template File Provisioning**: Provision files directly from template definitions
-- **AWS Cost Testing**: Complete integration test suite with cost tracking
-- **Instance Lifecycle Testing**: Full workflow validation including cleanup
-
-### v0.5.6 - Complete Prism Rebrand
-- **Project Rename**: CloudWorkStation → Prism (complete rebrand)
-- **Repository Rename**: `prism` → `prism` on GitHub
-- **Configuration Directory**: `.prism` → `.prism`
-- **Module Path Update**: Complete Go module path migration
-
-### v0.5.5 - AWS Research Services Integration
-- **EMR Studio**: Big data analytics and Spark-based research
-- **Amazon Braket**: Quantum computing research access
-- **Web Service Framework**: Unified interface for EC2 + AWS research services
-
-### v0.5.4 - Universal Version System
-- **Dynamic OS Versions**: Choose OS versions at launch time with `--version` flag
-- **Version Aliases**: Support for `latest`, `lts`, `previous-lts`
-- **AMI Freshness Checking**: `prism ami check-freshness` validates static AMI IDs
-- **AWS SSM Integration**: Automatic latest AMI discovery for major distributions
-- **Package Management**: Available via Homebrew (macOS), Scoop (Windows), deb, rpm, apk
-
-### v0.5.3 - Research User System & Template Marketplace
-- **Multi-User Architecture**: Persistent research identities across workspaces
-- **SSH Key Management**: Complete key generation and distribution
-- **Template Registry**: Multi-registry support with community templates
-- **Policy Framework**: Institutional governance and access control
-
-### v0.4.5 - Enterprise Research Platform
-- **Project-Based Organization**: Multi-user projects with role-based access
-- **Budget Management**: Real-time cost tracking and automated controls
-- **Hibernation Ecosystem**: Manual + automated idle detection policies
-- **Template Inheritance**: Stackable template system
+See **[CHANGELOG.md](CHANGELOG.md)** for the full, up-to-date version history
+following [Keep a Changelog](https://keepachangelog.com/) and semantic versioning.
 
 ## 🚀 Roadmap
 
@@ -376,12 +306,12 @@ make test
 
 ## 🆘 Support
 
-- **Documentation**: [Complete docs site](https://scttfrdmn.github.io/prism/) or `prism --help`
-- **System Check**: `prism doctor`
+- **Documentation**: [Complete docs site](https://docs.prismcloud.host/) or `prism --help`
+- **System Check**: `prism admin daemon status`
 - **Issues**: [GitHub Issues](https://github.com/scttfrdmn/prism/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/scttfrdmn/prism/discussions)
 - **AWS Setup**: See [AWS Setup Guide](docs/user-guides/AWS_SETUP_GUIDE.md)
 
 ---
 
-**Prism v0.5.11** - Research computing environments made accessible | [prismcloud.io](https://prismcloud.io)
+**Prism** - Research computing environments made accessible | [prismcloud.host](https://prismcloud.host)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Prism provides researchers with **pre-configured cloud workstations** for data a
 
 **From individual researchers to institutional deployments** - research computing made simple, scalable, and cost-effective.
 
-**Learn more at [prismcloud.io](https://prismcloud.io)**
+**Learn more at [prismcloud.host](https://prismcloud.host)**
 
 ## 🎯 Core Design Principles
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-prismcloud.io
+prismcloud.host

--- a/docs/RESOURCE_TAGGING.md
+++ b/docs/RESOURCE_TAGGING.md
@@ -577,6 +577,6 @@ Plus:
 
 ## Related Documentation
 
-- [Multi-Budget System](docs/BUDGET_PHILOSOPHY.md) (Issue #236 - planned)
-- [Project Management](docs/USER_GUIDE_PROJECTS.md)
-- [AWS Setup Guide](docs/AWS_SETUP.md)
+- Multi-Budget System (Issue #236 - planned)
+- Project Management
+- AWS Setup Guide

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,7 +50,7 @@ Candidates (to be prioritized):
 ### v0.6.0 (December 2025): Test Infrastructure & API Documentation ✅ RELEASED
 **Release Date**: December 13, 2025
 **Focus**: Backend unit test foundation and Phase 4/5 API documentation
-**Release Notes**: [RELEASE_NOTES_v0.6.0.md](releases/RELEASE_NOTES_v0.6.0.md)
+**Release Notes**: RELEASE_NOTES_v0.6.0.md
 
 #### Features Delivered
 
@@ -84,8 +84,8 @@ Candidates (to be prioritized):
 ### v0.6.1 (December 2025): Pragmatic Testing Strategy ✅ IN PROGRESS
 **Release Date**: Target December 27, 2025
 **Focus**: Production-ready release with measured coverage and clear technical debt tracking
-**Coverage Report**: [COVERAGE_v0.6.1.md](COVERAGE_v0.6.1.md)
-**Planning Doc**: [TESTING_IMPROVEMENT_ROADMAP.md](releases/TESTING_IMPROVEMENT_ROADMAP.md)
+**Coverage Report**: COVERAGE_v0.6.1.md
+**Planning Doc**: TESTING_IMPROVEMENT_ROADMAP.md
 
 #### Status: Ready for Release
 
@@ -235,7 +235,7 @@ Candidates (to be prioritized):
 **Release Date**: January 15, 2026
 **Focus**: Chaos engineering, edge case coverage, LocalStack integration, enterprise features
 **GitHub Milestone**: [v0.7.0](https://github.com/scttfrdmn/prism/milestone/40)
-**Release Notes**: [RELEASE_NOTES_v0.7.0.md](releases/RELEASE_NOTES_v0.7.0.md)
+**Release Notes**: RELEASE_NOTES_v0.7.0.md
 
 #### Goals
 
@@ -364,8 +364,8 @@ Candidates (to be prioritized):
 ### v0.5.8 (November 2025): Quick Start Experience ✅ RELEASED
 **Release Date**: November 8, 2025
 **Focus**: First-time user experience - zero to workspace in <30 seconds
-**Release Plan**: [RELEASE_PLAN_v0.5.8.md](releases/RELEASE_PLAN_v0.5.8.md)
-**Release Notes**: [RELEASE_NOTES_v0.5.8.md](releases/RELEASE_NOTES_v0.5.8.md)
+**Release Plan**: RELEASE_PLAN_v0.5.8.md
+**Release Notes**: RELEASE_NOTES_v0.5.8.md
 
 #### Quick Start Features ✅ COMPLETE
 **Milestone**: [Phase 5.0.1: Quick Wins](https://github.com/scttfrdmn/prism/milestone/2) - 100% Complete
@@ -394,8 +394,8 @@ Candidates (to be prioritized):
 ### v0.5.9 (November 2025): Navigation Restructure ✅
 **Release Date**: November 7, 2025
 **Focus**: Reduce navigation complexity from 14 to 6 items
-**Release Plan**: [RELEASE_PLAN_v0.5.9.md](releases/RELEASE_PLAN_v0.5.9.md)
-**Release Notes**: [RELEASE_NOTES_v0.5.9.md](releases/RELEASE_NOTES_v0.5.9.md)
+**Release Plan**: RELEASE_PLAN_v0.5.9.md
+**Release Notes**: RELEASE_NOTES_v0.5.9.md
 
 #### Navigation Features
 **Milestones**: [Phase 5.0.2: Info Architecture](https://github.com/scttfrdmn/prism/milestone/3)
@@ -435,7 +435,7 @@ Candidates (to be prioritized):
 ### v0.5.10 (November 2025): Multi-Project Budgets ✅ RELEASED (Core Infrastructure)
 **Release Date**: November 8, 2025
 **Focus**: Budget system core infrastructure for multi-project allocation
-**Release Plan**: [RELEASE_PLAN_v0.5.10.md](releases/RELEASE_PLAN_v0.5.10.md)
+**Release Plan**: RELEASE_PLAN_v0.5.10.md
 
 **Note**: v0.5.10 delivered the **core budget tracking backend** (5,300+ lines). GUI completion and soft warnings will be added in v0.6.0 (Issue #369).
 
@@ -561,7 +561,7 @@ Candidates (to be prioritized):
 **Release Date**: November 12, 2025
 **Focus**: Advanced cost control and system power management
 **Issues**: #90, #91, #252
-**Release Notes**: [RELEASE_NOTES_v0.5.13.md](releases/RELEASE_NOTES_v0.5.13.md)
+**Release Notes**: RELEASE_NOTES_v0.5.13.md
 
 #### Features In Development
 
@@ -615,7 +615,7 @@ Candidates (to be prioritized):
 **Focus**: Nice DCV foundation for desktop GUI applications
 **Issues**: #253-#256
 **Milestone**: [v0.5.14](https://github.com/scttfrdmn/prism/milestone/33)
-**Release Plan**: [RELEASE_PLAN_v0.5.14.md](releases/RELEASE_PLAN_v0.5.14.md)
+**Release Plan**: RELEASE_PLAN_v0.5.14.md
 
 #### Completed Features
 
@@ -1783,15 +1783,15 @@ Create an issue: [github.com/scttfrdmn/prism/issues/new](https://github.com/sctt
 Join discussions: [github.com/scttfrdmn/prism/discussions](https://github.com/scttfrdmn/prism/discussions)
 
 **Technical implementation details?**  
-See: [Technical Debt Backlog](archive/roadmap/TECHNICAL_DEBT_BACKLOG.md)
+See: Technical Debt Backlog
 
 ---
 
 ## 📚 Related Documentation
 
 - [VISION.md](VISION.md) - Long-term product vision
-- [UX Evaluation](architecture/UX_EVALUATION_AND_RECOMMENDATIONS.md) - Current UX issues
-- [Technical Debt Backlog](archive/roadmap/TECHNICAL_DEBT_BACKLOG.md) - Implementation tracking
+- UX Evaluation - Current UX issues
+- Technical Debt Backlog - Implementation tracking
 - [GitHub Projects](https://github.com/scttfrdmn/prism/projects) - Sprint planning
 
 ---

--- a/docs/TEMPLATE_FILE_PROVISIONING.md
+++ b/docs/TEMPLATE_FILE_PROVISIONING.md
@@ -511,8 +511,8 @@ userData += script
 
 ## See Also
 
-- [S3 Transfer API Documentation](S3_TRANSFER_API.md)
-- [Template Schema Reference](TEMPLATE_SCHEMA.md)
+- S3 Transfer API Documentation
+- Template Schema Reference
 - [IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
 - [S3 Pricing](https://aws.amazon.com/s3/pricing/)
 

--- a/docs/USER_SCENARIOS/06_NIH_RESEARCHER_CUI_COMPLIANCE.md
+++ b/docs/USER_SCENARIOS/06_NIH_RESEARCHER_CUI_COMPLIANCE.md
@@ -640,7 +640,7 @@ prism admin compliance summary --institution
 ## Related Documentation
 
 - **[NIST 800-171 Compliance Guide](../admin-guides/NIST_800_171_COMPLIANCE.md)** - Detailed control-by-control compliance mapping
-- **[Security & Compliance Roadmap](../admin-guides/SECURITY_COMPLIANCE_ROADMAP.md)** - Comprehensive compliance framework
+- **Security & Compliance Roadmap** - Comprehensive compliance framework
 - **[Compliance Matrix](../admin-guides/COMPLIANCE_MATRIX.md)** - Quick reference for all frameworks
 
 ---

--- a/docs/USER_SCENARIOS/07_NIH_RESEARCHER_PHI_HIPAA_COMPLIANCE.md
+++ b/docs/USER_SCENARIOS/07_NIH_RESEARCHER_PHI_HIPAA_COMPLIANCE.md
@@ -172,7 +172,7 @@ If discovered during routine audit:
 
 1. **Medical Center IT Security Recommends Prism**:
    - University Medical Center IT Security validated Prism for HIPAA research
-   - Provides compliance documentation: [HIPAA_COMPLIANCE_GUIDE.md](../admin-guides/HIPAA_COMPLIANCE_GUIDE.md) (v0.8.0)
+   - Provides compliance documentation: HIPAA_COMPLIANCE_GUIDE.md (v0.8.0)
    - Meets HIPAA Technical Safeguards via NIST 800-53 control mapping
    - Includes Business Associate Agreement (BAA) framework for AWS
 
@@ -791,9 +791,9 @@ $ prism admin compliance summary --institution --framework HIPAA
 
 ## Related Documentation
 
-- **[HIPAA Compliance Guide](../admin-guides/HIPAA_COMPLIANCE_GUIDE.md)** - Detailed HIPAA Security Rule implementation (v0.8.0 - Q4 2026)
+- **HIPAA Compliance Guide** - Detailed HIPAA Security Rule implementation (v0.8.0 - Q4 2026)
 - **[NIST 800-171 Compliance Guide](../admin-guides/NIST_800_171_COMPLIANCE.md)** - CUI compliance (Persona 6 comparison)
-- **[Security & Compliance Roadmap](../admin-guides/SECURITY_COMPLIANCE_ROADMAP.md)** - Comprehensive compliance framework
+- **Security & Compliance Roadmap** - Comprehensive compliance framework
 - **[Compliance Matrix](../admin-guides/COMPLIANCE_MATRIX.md)** - Quick reference for all frameworks
 
 ---

--- a/docs/admin-guides/ADMINISTRATOR_GUIDE.md
+++ b/docs/admin-guides/ADMINISTRATOR_GUIDE.md
@@ -185,6 +185,6 @@ Resolution:
 
 ## Technical References
 
-- [Secure Profile Implementation](SECURE_PROFILE_IMPLEMENTATION.md): Detailed technical documentation
+- Secure Profile Implementation: Detailed technical documentation
 - [Profile Export/Import Guide](PROFILE_EXPORT_IMPORT.md): Information on secure profile migration
-- [Secure Invitation Architecture](SECURE_INVITATION_ARCHITECTURE.md): Design documentation
+- Secure Invitation Architecture: Design documentation

--- a/docs/admin-guides/ADMINISTRATOR_GUIDE_BATCH.md
+++ b/docs/admin-guides/ADMINISTRATOR_GUIDE_BATCH.md
@@ -398,4 +398,4 @@ with open(sys.argv[1], 'r') as infile:
 
 The batch invitation system provides powerful tools for managing Prism access at scale. By following the strategies and best practices in this guide, administrators can efficiently manage invitations across organizations of any size while maintaining security and control.
 
-For more detailed information about specific interfaces, refer to the [Batch Invitation Interface Guide](./BATCH_INVITATION_INTERFACE_GUIDE.md).
+For more detailed information about specific interfaces, refer to the Batch Invitation Interface Guide.

--- a/docs/admin-guides/AWS_IAM_PERMISSIONS.md
+++ b/docs/admin-guides/AWS_IAM_PERMISSIONS.md
@@ -1,504 +1,239 @@
 # Prism AWS IAM Permissions
 
-**Last Updated**: October 17, 2025
+This document defines the AWS IAM permissions Prism needs, why each is required,
+and how to set them up. It reflects the permissions the current codebase actually
+calls.
 
-This document defines the minimum AWS IAM permissions required for Prism to function properly.
+There are **two distinct policies**:
+
+1. **User / daemon policy** — attached to the IAM user (or role) whose credentials
+   you run Prism with. This is the one you attach to yourself. See
+   [`prism-iam-policy.json`](../prism-iam-policy.json).
+2. **Instance role** (`Prism-Instance-Profile-Role`) — attached to each *workspace*
+   so it can use SSM and stop itself when idle. Prism **auto-creates** this on first
+   launch; you only need to pre-provision it manually if your user lacks IAM
+   permissions. See [`prism-instance-role-policy.json`](../prism-instance-role-policy.json).
+
+An optional add-on policy covers compliance reporting and the template marketplace:
+[`prism-iam-policy-optional.json`](../prism-iam-policy-optional.json).
 
 ---
 
-## Overview
+## How Prism authenticates
 
-Prism requires AWS credentials with sufficient permissions to manage EC2 instances, EFS filesystems, IAM roles, and Systems Manager (SSM) operations. Users must have an AWS account with either:
+Run Prism with AWS credentials from any standard source:
 
-1. **AWS Access Keys** (Access Key ID + Secret Access Key) stored in `~/.aws/credentials`
-2. **AWS IAM Role** attached to the machine running Prism (for EC2/ECS deployments)
-3. **AWS SSO credentials** configured via `aws sso login`
+1. **Browser login (recommended)** — `aws login` (AWS CLI v2.32+), which uses IAM
+   Identity Center / federated identity with no long-term keys.
+2. **Long-term access keys** — `aws configure`, stored in `~/.aws/credentials`.
+3. **An attached IAM role** — when running Prism on an EC2/ECS host.
+
+See the [AWS Setup Guide](../user-guides/AWS_SETUP_GUIDE.md) for the full walkthrough.
+Whatever the source, the identity needs the user/daemon policy below.
 
 ---
 
-## Quick Start: Recommended Setup
-
-For new users, Prism provides a **managed IAM policy** that grants all necessary permissions:
+## Quick start
 
 ```bash
-# Option 1: Attach AWS managed policy (if available in future)
-aws iam attach-user-policy \
-  --user-name YOUR_USERNAME \
-  --policy-arn arn:aws:iam::aws:policy/PrismFullAccess
-
-# Option 2: Create custom policy from this document
+# Create the user/daemon policy from the checked-in JSON
 aws iam create-policy \
   --policy-name PrismAccess \
-  --policy-document file://prism-policy.json
+  --policy-document file://prism-iam-policy.json
 
+# Attach it to your IAM user
 aws iam attach-user-policy \
   --user-name YOUR_USERNAME \
   --policy-arn arn:aws:iam::YOUR_ACCOUNT_ID:policy/PrismAccess
 ```
 
----
-
-## Minimum Required Permissions
-
-Prism requires the following AWS service permissions:
-
-### 1. **EC2 (Elastic Compute Cloud)** - Core Instance Management
-
-**Required Actions:**
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "EC2InstanceManagement",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:RunInstances",
-        "ec2:TerminateInstances",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:DescribeInstances",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstanceTypeOfferings",
-        "ec2:DescribeImages",
-        "ec2:DescribeVolumes",
-        "ec2:CreateVolume",
-        "ec2:DeleteVolume",
-        "ec2:CreateTags",
-        "ec2:DescribeTags"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "EC2NetworkManagement",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DescribeVpcs",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeSecurityGroups",
-        "ec2:CreateSecurityGroup",
-        "ec2:AuthorizeSecurityGroupIngress"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "EC2KeyPairManagement",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DescribeKeyPairs",
-        "ec2:ImportKeyPair",
-        "ec2:DeleteKeyPair"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-**Why These Permissions:**
-- **RunInstances**: Launch new Prism instances
-- **Stop/Start/Terminate**: Instance lifecycle management
-- **DescribeInstances**: List and monitor running instances
-- **DescribeImages**: Find optimal AMIs for templates
-- **CreateSecurityGroup**: Automatic security group creation for SSH/web access
-- **ImportKeyPair**: Manage SSH keys for instance access
-
-### 2. **EFS (Elastic File System)** - Persistent Storage
-
-**Required Actions:**
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "EFSVolumeManagement",
-      "Effect": "Allow",
-      "Action": [
-        "elasticfilesystem:CreateFileSystem",
-        "elasticfilesystem:DeleteFileSystem",
-        "elasticfilesystem:DescribeFileSystems",
-        "elasticfilesystem:DescribeMountTargets",
-        "elasticfilesystem:CreateMountTarget",
-        "elasticfilesystem:DeleteMountTarget",
-        "elasticfilesystem:CreateTags",
-        "elasticfilesystem:DescribeTags"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-**Why These Permissions:**
-- **CreateFileSystem**: Create shared EFS volumes for research data
-- **CreateMountTarget**: Attach EFS to instances across availability zones
-- **DescribeMountTargets**: Monitor volume attachments
-- Multi-instance file sharing for collaborative research
-
-### 3. **IAM (Identity and Access Management)** - Instance Profiles
-
-**Required Actions:**
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "IAMInstanceProfileManagement",
-      "Effect": "Allow",
-      "Action": [
-        "iam:GetInstanceProfile",
-        "iam:CreateRole",
-        "iam:AttachRolePolicy",
-        "iam:PutRolePolicy",
-        "iam:CreateInstanceProfile",
-        "iam:AddRoleToInstanceProfile",
-        "iam:PassRole"
-      ],
-      "Resource": [
-        "arn:aws:iam::*:role/Prism-Instance-Profile-Role",
-        "arn:aws:iam::*:instance-profile/Prism-Instance-Profile"
-      ]
-    }
-  ]
-}
-```
-
-**Why These Permissions:**
-- **CreateRole**: Auto-create Prism-Instance-Profile for SSM access
-- **AttachRolePolicy**: Attach AmazonSSMManagedInstanceCore for Systems Manager
-- **PutRolePolicy**: Create inline policy for autonomous idle detection
-- **PassRole**: Allow EC2 to assume the Prism role
-
-**What This Enables:**
-- **SSM Access**: Remote command execution without SSH keys
-- **Autonomous Idle Detection**: Instances can stop themselves when idle
-- **Secure Management**: No SSH keys exposed, all commands via AWS Systems Manager
-
-### 4. **SSM (Systems Manager)** - Remote Command Execution
-
-**Required Actions:**
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "SSMCommandExecution",
-      "Effect": "Allow",
-      "Action": [
-        "ssm:SendCommand",
-        "ssm:GetCommandInvocation",
-        "ssm:DescribeInstanceInformation"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-**Why These Permissions:**
-- **SendCommand**: Execute remote scripts for software installation, user provisioning
-- **GetCommandInvocation**: Monitor command execution status
-- Used for EFS mounting, template provisioning, research user setup
-
-### 5. **STS (Security Token Service)** - Identity Verification
-
-**Required Actions:**
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "STSIdentityVerification",
-      "Effect": "Allow",
-      "Action": [
-        "sts:GetCallerIdentity"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-**Why These Permissions:**
-- Verify AWS credentials are valid
-- Retrieve AWS account ID for resource naming
+Prefer least privilege? Start with the **Core tier** below (EC2 + STS) and add
+service blocks as you enable features. Prism degrades gracefully: if a permission
+is missing, that feature is unavailable — it does not crash the tool.
 
 ---
 
-## Complete IAM Policy
+## User / daemon policy — by service
 
-Here is the **complete Prism IAM policy** combining all permissions:
+The complete policy is [`prism-iam-policy.json`](../prism-iam-policy.json). Each
+block below explains what it enables.
 
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "EC2InstanceManagement",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:RunInstances",
-        "ec2:TerminateInstances",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:DescribeInstances",
-        "ec2:DescribeInstanceStatus",
-        "ec2:DescribeInstanceTypes",
-        "ec2:DescribeInstanceTypeOfferings",
-        "ec2:DescribeImages",
-        "ec2:DescribeVolumes",
-        "ec2:CreateVolume",
-        "ec2:DeleteVolume",
-        "ec2:AttachVolume",
-        "ec2:DetachVolume",
-        "ec2:CreateTags",
-        "ec2:DescribeTags"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "EC2NetworkManagement",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DescribeVpcs",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeAvailabilityZones",
-        "ec2:DescribeSecurityGroups",
-        "ec2:CreateSecurityGroup",
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:RevokeSecurityGroupIngress"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "EC2KeyPairManagement",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DescribeKeyPairs",
-        "ec2:ImportKeyPair",
-        "ec2:DeleteKeyPair"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "EFSVolumeManagement",
-      "Effect": "Allow",
-      "Action": [
-        "elasticfilesystem:CreateFileSystem",
-        "elasticfilesystem:DeleteFileSystem",
-        "elasticfilesystem:DescribeFileSystems",
-        "elasticfilesystem:DescribeMountTargets",
-        "elasticfilesystem:CreateMountTarget",
-        "elasticfilesystem:DeleteMountTarget",
-        "elasticfilesystem:CreateTags",
-        "elasticfilesystem:DescribeTags"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "IAMInstanceProfileManagement",
-      "Effect": "Allow",
-      "Action": [
-        "iam:GetRole",
-        "iam:GetInstanceProfile",
-        "iam:CreateRole",
-        "iam:TagRole",
-        "iam:AttachRolePolicy",
-        "iam:PutRolePolicy",
-        "iam:CreateInstanceProfile",
-        "iam:TagInstanceProfile",
-        "iam:AddRoleToInstanceProfile",
-        "iam:PassRole"
-      ],
-      "Resource": [
-        "arn:aws:iam::*:role/Prism-Instance-Profile-Role",
-        "arn:aws:iam::*:instance-profile/Prism-Instance-Profile"
-      ]
-    },
-    {
-      "Sid": "SSMCommandExecution",
-      "Effect": "Allow",
-      "Action": [
-        "ssm:SendCommand",
-        "ssm:GetCommandInvocation",
-        "ssm:ListCommands",
-        "ssm:ListCommandInvocations",
-        "ssm:DescribeInstanceInformation"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "STSIdentityVerification",
-      "Effect": "Allow",
-      "Action": [
-        "sts:GetCallerIdentity"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
+### EC2 — instance, storage, networking, keys (required)
+
+Core lifecycle: `RunInstances`, `TerminateInstances`, `Start/StopInstances`,
+`DescribeInstances`, `DescribeInstanceStatus`, `DescribeInstanceTypes`,
+`DescribeInstanceTypeOfferings`, `DescribeImages`.
+
+Storage: `CreateVolume`, `DeleteVolume`, `AttachVolume`, `DetachVolume`,
+`ModifyVolume` (resize), `DescribeVolumes`.
+
+Instance config & diagnostics: `ModifyInstanceAttribute`, `GetConsoleOutput`,
+`CreateTags`, `DescribeTags`.
+
+Networking: `DescribeVpcs`, `DescribeSubnets`, `DescribeAvailabilityZones`,
+`DescribeRouteTables`, `DescribeSecurityGroups`, `CreateSecurityGroup`,
+`Authorize/RevokeSecurityGroupIngress`.
+
+Keys: `DescribeKeyPairs`, `ImportKeyPair`, `DeleteKeyPair`.
+
+### EC2 spot pricing (recommended)
+
+`DescribeSpotPriceHistory` — real-time spot rate lookups for cost estimates and
+`--spot` launches.
+
+### EC2 snapshots & AMIs (for snapshot / custom-AMI features)
+
+`CreateImage`, `RegisterImage`, `DeregisterImage`, `ModifyImageAttribute`,
+`CreateSnapshot`, `DeleteSnapshot`, `DescribeSnapshots` — used by
+`prism snapshot`, `prism ami`, and template-to-AMI workflows.
+
+### EC2 capacity reservations (for `prism capacity-block`)
+
+`CreateCapacityReservation`, `DescribeCapacityReservations`,
+`CancelCapacityReservation` — reserved GPU/ML capacity blocks.
+
+### EFS — shared filesystems (recommended)
+
+`CreateFileSystem`, `DeleteFileSystem`, `DescribeFileSystems`,
+`Create/Delete/DescribeMountTargets`, `Create/DescribeTags` — `prism volume`
+shared storage across workspaces.
+
+### FSx for Lustre — high-performance storage (optional)
+
+`CreateFileSystem`, `DeleteFileSystem`, `UpdateFileSystem`, `DescribeFileSystems`,
+`TagResource`, `ListTagsForResource` — high-throughput scratch storage for HPC.
+
+### S3 — file transfer, backups, EFS staging (recommended)
+
+`CreateBucket`, `ListBucket`, `GetBucketLocation`, `GetObject`, `PutObject`,
+`DeleteObject`, scoped to Prism-owned buckets:
+`prism-temp-*` (SSM file push/pull), `prism-backups-*` (`prism backup`),
+`prism-efs-*` (EFS staging), and `prism-transfer*` (S3-backed transfers).
+
+### IAM — instance profile (recommended; scoped)
+
+`GetRole`, `GetInstanceProfile`, `CreateRole`, `TagRole`, `AttachRolePolicy`,
+`PutRolePolicy`, `CreateInstanceProfile`, `TagInstanceProfile`,
+`AddRoleToInstanceProfile`, `PassRole` — **scoped to the Prism role/profile ARNs
+only**. Lets Prism auto-create `Prism-Instance-Profile-Role` (see below). Without
+it, workspaces launch but SSM and autonomous idle detection are unavailable.
+
+### SSM — remote command execution (recommended)
+
+`SendCommand`, `GetCommandInvocation`, `ListCommands`, `ListCommandInvocations`,
+`DescribeInstanceInformation` — provisioning, EFS mounting, research-user setup,
+and file operations without SSH keys.
+
+### Pricing & Cost Explorer — cost features (recommended)
+
+`pricing:GetProducts` — region-aware on-demand/spot rate lookups (via truffle).
+`ce:GetCostAndUsage`, `ce:GetCostForecast` — billed-cost reconciliation, budget
+tracking, discount/credit discovery, and storage cost analytics.
+
+### CloudWatch — rightsizing & metrics (optional)
+
+`GetMetricStatistics`, `GetMetricData`, `ListMetrics` — `prism` rightsizing
+recommendations and volume/instance metrics.
+
+### Service Quotas — launch preflight (recommended)
+
+`GetServiceQuota`, `ListServiceQuotas` — checks your vCPU quota before a launch so
+you get a clear message instead of an opaque `RunInstances` failure.
+
+### STS — identity (required)
+
+`GetCallerIdentity` — validates credentials and resolves the account ID used for
+resource naming and DNS subdomains.
 
 ---
 
-## Permission Tiers
+## Optional add-on policy
 
-Prism supports different permission levels based on institutional requirements:
+[`prism-iam-policy-optional.json`](../prism-iam-policy-optional.json) — attach only
+if you use these features:
 
-### **Tier 1: Basic Usage** (Minimum Required)
-- EC2 instance management (launch, stop, terminate)
-- EC2 networking (VPC, security groups, subnets)
-- SSH key pair management
-- STS identity verification
-
-**Missing Features Without Tier 2:**
-- No persistent EFS storage (only local instance storage)
-- No SSM access (must use SSH keys)
-- No autonomous idle detection
-
-### **Tier 2: Full Features** (Recommended)
-- All Tier 1 permissions
-- EFS filesystem creation and management
-- IAM instance profile auto-creation
-- SSM remote command execution
-
-**Enables:**
-- Multi-instance shared storage
-- Zero-configuration SSM access
-- Autonomous cost optimization (idle detection)
-
-### **Tier 3: Institutional Deployment** (Future)
-- All Tier 2 permissions
-- Additional permissions for:
-  - CloudFormation stack creation (one-click institutional setup)
-  - AWS Cost Explorer API access (detailed cost analytics)
-  - AWS Organizations integration (multi-account management)
+- **Compliance reporting** (`prism` compliance views): `organizations:ListPolicies`,
+  `organizations:DescribeOrganization`, `artifact:ListReports`, `artifact:GetReport`.
+- **Template marketplace registry** (`prism marketplace`): `dynamodb:*` on
+  `prism-*` tables.
 
 ---
 
-## Security Best Practices
+## Instance role — `Prism-Instance-Profile-Role`
 
-### 1. **Use IAM Users, Not Root Credentials**
-Never use AWS root account credentials with Prism. Create a dedicated IAM user:
+This is a **separate role attached to each workspace**, not to you. Prism
+auto-creates it on first launch (when your user policy includes the scoped `iam:*`
+actions above). It is:
+
+- **Trust policy**: `ec2.amazonaws.com` may `sts:AssumeRole`.
+- **AWS-managed policy**: `AmazonSSMManagedInstanceCore` (SSM agent connectivity).
+- **Inline policy** ([`prism-instance-role-policy.json`](../prism-instance-role-policy.json)):
+  `ec2:CreateTags`, `DescribeTags`, `DescribeInstances`, `StopInstances` — lets the
+  on-instance agent (spored) tag itself and stop the instance when idle.
+
+**Pre-provisioning**: if end users can't be granted `iam:CreateRole`, an
+administrator can create this role + instance profile once (named exactly
+`Prism-Instance-Profile-Role` / `Prism-Instance-Profile`) and Prism will use it.
+
+**Known limitation**: the auto-created inline policy does **not** grant the S3-read
+or Route53 permissions that spored uses for its binary download and DNS
+self-registration (`*.prismcloud.host`). Those rely on separately-provisioned
+access; DNS registration and SSM file-pull to fresh instances may be unavailable
+under the minimal auto-created role until this is closed. Track/adjust if you rely
+on custom DNS.
+
+---
+
+## Permission tiers
+
+**Core (minimum to launch)** — EC2 (instance/network/keys) + STS. You can launch,
+stop, and terminate SSH-accessible workspaces. No shared storage, no SSM, no cost
+analytics.
+
+**Recommended (full single-user experience)** — Core + EFS + IAM (scoped) + SSM +
+Pricing/Cost Explorer + Service Quotas + S3 + spot pricing. This is
+`prism-iam-policy.json` and what most researchers should attach.
+
+**Optional** — FSx, CloudWatch, snapshots/AMIs, capacity reservations (in the main
+policy but only exercised by those features) plus the compliance/marketplace add-on.
+
+---
+
+## Security best practices
+
+1. **Never use root credentials.** Create a dedicated IAM user or use IAM Identity
+   Center (`aws login`).
+2. **Scope by tag** where possible — Prism tags all resources `ManagedBy=Prism` /
+   `Prism=true`, so you can add a condition limiting Prism to its own resources.
+3. **Prefer short-lived credentials** (`aws login` / SSO) over long-term keys.
+4. **Enable CloudTrail** to audit the API calls Prism makes.
+
+---
+
+## Troubleshooting
+
+**`You are not authorized to perform this operation`** — attach the missing service
+block from `prism-iam-policy.json`. The error names the action; find its block above.
+
+**`User is not authorized to perform: iam:CreateRole`** — your user lacks the scoped
+IAM permissions. Either add them, or have an admin pre-provision
+`Prism-Instance-Profile-Role` (see above). Workspaces still launch (SSH-only);
+SSM and idle detection are disabled.
+
+**`AccessDenied` on cost or pricing calls** — add the Pricing / Cost Explorer block;
+cost estimates fall back to a static table without it.
+
+Verify your identity and permissions:
 
 ```bash
-aws iam create-user --user-name prism-admin
-aws iam create-access-key --user-name prism-admin
-aws iam attach-user-policy \
-  --user-name prism-admin \
-  --policy-arn arn:aws:iam::YOUR_ACCOUNT_ID:policy/PrismAccess
-```
-
-### 2. **Restrict Permissions with Resource Tags**
-Limit Prism to only manage its own resources:
-
-```json
-{
-  "Condition": {
-    "StringEquals": {
-      "aws:ResourceTag/ManagedBy": "Prism"
-    }
-  }
-}
-```
-
-### 3. **Use AWS Profiles for Multi-Account Management**
-Separate research projects into different AWS accounts:
-
-```bash
-# ~/.aws/credentials
-[research-project-1]
-aws_access_key_id = AKIA...
-aws_secret_access_key = ...
-
-[research-project-2]
-aws_access_key_id = AKIA...
-aws_secret_access_key = ...
-
-# Prism profiles
-prism profiles add project1 proj1-profile --aws-profile research-project-1 --region us-west-2
-prism profiles add project2 proj2-profile --aws-profile research-project-2 --region us-east-1
-```
-
-### 4. **Enable CloudTrail Logging**
-Track all AWS API calls made by Prism:
-
-```bash
-aws cloudtrail create-trail \
-  --name prism-audit \
-  --s3-bucket-name YOUR_AUDIT_BUCKET
+aws sts get-caller-identity
+prism workspace launch "Basic Ubuntu (APT)" test --dry-run   # shows what would be created
 ```
 
 ---
 
-## Common Permission Issues
+## Getting help
 
-### **Error: "You are not authorized to perform this operation"**
-
-**Cause**: Missing required IAM permissions
-
-**Solution**: Attach the Prism IAM policy to your IAM user/role
-
-### **Error: "User is not authorized to perform: iam:CreateRole"**
-
-**Cause**: User lacks IAM permissions for instance profile auto-creation
-
-**Impact**: SSM access and autonomous idle detection will be unavailable
-
-**Solutions**:
-1. **Recommended**: Request IAM permissions from AWS administrator
-2. **Workaround**: Manually create Prism-Instance-Profile in AWS console
-3. **Fallback**: Continue without IAM profile (SSH-only access, no autonomous features)
-
-### **Error: "Failed to create EFS filesystem: AccessDeniedException"**
-
-**Cause**: Missing EFS permissions
-
-**Impact**: Cannot create persistent shared storage volumes
-
-**Solution**: Add EFS permissions to IAM policy
-
----
-
-## Verification
-
-Test your IAM permissions with Prism:
-
-```bash
-# Test EC2 permissions
-prism templates  # Should list available templates
-prism workspace launch ubuntu test-instance --dry-run  # Should show what would be created
-
-# Test EFS permissions (if you have them)
-prism volume create test-volume  # Should create EFS filesystem
-
-# Test IAM permissions (if you have them)
-# Prism will automatically create instance profile on first launch
-prism workspace launch ubuntu test-instance
-# Check logs for: "✅ Successfully created IAM instance profile 'Prism-Instance-Profile'"
-```
-
----
-
-## Getting Help
-
-If you encounter permission issues:
-
-1. **Check AWS IAM Policy Simulator**: https://policysim.aws.amazon.com/
-2. **Review CloudTrail logs**: See which API calls are being denied
-3. **Contact AWS Support**: For enterprise/educational account assistance
-4. **Prism Issues**: https://github.com/anthropics/prism/issues
-
----
-
-## Future Enhancements
-
-### Planned Improvements
-- **AWS CloudFormation Template**: One-click IAM setup for institutions
-- **Least-Privilege Policies**: More restrictive resource-level permissions
-- **AWS Organizations Integration**: Multi-account research management
-- **Cost Explorer Integration**: Detailed cost analytics and budget tracking
-
----
-
-**Summary**: Prism requires EC2, EFS, IAM, SSM, and STS permissions for full functionality. Basic usage requires only EC2 permissions, but EFS and IAM permissions enable persistent storage and autonomous features. Users should create a dedicated IAM user with the Prism policy for secure access.
+- **IAM Policy Simulator**: https://policysim.aws.amazon.com/
+- **CloudTrail**: review which API calls are denied
+- **Issues**: https://github.com/scttfrdmn/prism/issues

--- a/docs/admin-guides/AWS_QUOTA_MANAGEMENT.md
+++ b/docs/admin-guides/AWS_QUOTA_MANAGEMENT.md
@@ -462,7 +462,7 @@ Press 'r' to refresh | Press 'q' to quit
 
 ## Related Documentation
 
-- **Technical Debt Backlog**: [TECHNICAL_DEBT_BACKLOG.md](../archive/roadmap/TECHNICAL_DEBT_BACKLOG.md) (Item #2)
+- **Technical Debt Backlog**: TECHNICAL_DEBT_BACKLOG.md (Item #2)
 - **GitHub Issues**: [#57](https://github.com/scttfrdmn/prism/issues/57), [#58](https://github.com/scttfrdmn/prism/issues/58), [#59](https://github.com/scttfrdmn/prism/issues/59), [#60](https://github.com/scttfrdmn/prism/issues/60)
 - **AWS IAM Permissions**: [AWS_IAM_PERMISSIONS.md](AWS_IAM_PERMISSIONS.md) - Required permissions for quota APIs
 - **Administrator Guide**: [ADMINISTRATOR_GUIDE.md](ADMINISTRATOR_GUIDE.md) - General administration

--- a/docs/admin-guides/COMPLIANCE_MATRIX.md
+++ b/docs/admin-guides/COMPLIANCE_MATRIX.md
@@ -315,7 +315,7 @@ Quick reference for Prism compliance coverage across major security frameworks.
 | **Security Hardening** | [SECURITY_HARDENING_GUIDE.md](SECURITY_HARDENING_GUIDE.md) | ✅ Complete |
 | **AWS IAM** | [AWS_IAM_PERMISSIONS.md](AWS_IAM_PERMISSIONS.md) | ✅ Complete |
 | **Template Policies** | [TEMPLATE_POLICY_FRAMEWORK.md](TEMPLATE_POLICY_FRAMEWORK.md) | ✅ Complete |
-| **Security & Compliance** | [SECURITY_COMPLIANCE_ROADMAP.md](SECURITY_COMPLIANCE_ROADMAP.md) | ✅ Complete |
+| **Security & Compliance** | SECURITY_COMPLIANCE_ROADMAP.md | ✅ Complete |
 | **HIPAA** | `HIPAA_COMPLIANCE_GUIDE.md` | 🟠 Planned (v0.8.0) |
 | **FISMA** | `FISMA_COMPLIANCE_GUIDE.md` | 🟠 Planned (v0.7.0) |
 | **GDPR** | `GDPR_COMPLIANCE_GUIDE.md` | 🟠 Planned (v0.7.0) |

--- a/docs/admin-guides/RESEARCH_USER_MANAGEMENT_GUIDE.md
+++ b/docs/admin-guides/RESEARCH_USER_MANAGEMENT_GUIDE.md
@@ -25,26 +25,26 @@ This guide provides comprehensive information for managing research users in Pri
 
 ```bash
 # Research User Management
-prism research-user create <username>                    # Create research user
-prism research-user list                                 # List all research users
-prism research-user status <username>                   # Check user status
-prism research-user delete <username>                   # Remove research user
+prism user create <username>                    # Create research user
+prism user list                                 # List all research users
+prism user status <username>                   # Check user status
+prism user delete <username>                   # Remove research user
 
 # SSH Key Management
-prism research-user ssh-key generate <username> ed25519 # Generate SSH key pair
-prism research-user ssh-key import <username> <pubkey>  # Import existing key
-prism research-user ssh-key list <username>             # List user's keys
-prism research-user ssh-key delete <username> <key-id>  # Remove SSH key
+prism user keys generate <username> ed25519 # Generate SSH key pair
+prism user keys add <username> <pubkey>  # Import existing key
+prism user keys list <username>             # List user's keys
+prism user keys remove <username> <key-id>  # Remove SSH key
 
 # Instance Integration
 prism workspace launch <template> <instance> --research-user <username>  # Launch with research user
-prism research-user provision <username> --instance <name>     # Provision user on instance
-prism research-user status <username> --instance <name>        # Check user on instance
+prism user provision <username> --instance <name>     # Provision user on instance
+prism user status <username> --instance <name>        # Check user on instance
 
 # EFS and Storage
-prism volumes create <name>                             # Create EFS volume
-prism volumes mount <volume> <instance>                 # Mount EFS volume
-prism volumes list                                      # List EFS volumes
+prism volume create <name>                             # Create EFS volume
+prism volume mount <volume> <instance>                 # Mount EFS volume
+prism volume list                                      # List EFS volumes
 ```
 
 ### Key File Locations
@@ -144,57 +144,57 @@ prism volumes list                                      # List EFS volumes
 
 ```bash
 # Create research user with automatic UID assignment
-prism research-user create alice
+prism user create alice
 
 # Create with custom full name and email
-prism research-user create alice --full-name "Alice Smith" --email "alice@university.edu"
+prism user create alice --full-name "Alice Smith" --email "alice@university.edu"
 
 # Create with SSH key generation
-prism research-user create alice --generate-ssh-key
+prism user create alice --generate-ssh-key
 ```
 
 #### Advanced User Creation
 
 ```bash
 # Create with specific shell
-prism research-user create alice --shell /bin/zsh
+prism user create alice --shell /bin/zsh
 
 # Create with custom groups
-prism research-user create alice --groups research,docker,jupyter-users
+prism user create alice --groups research,docker,jupyter-users
 
 # Create with EFS configuration
-prism research-user create alice --efs-volume fs-1234567890abcdef0 --efs-mount /efs
+prism user create alice --efs-volume fs-1234567890abcdef0 --efs-mount /efs
 ```
 
 ### Modifying Research Users
 
 ```bash
 # Update user information
-prism research-user update alice --full-name "Dr. Alice Smith"
-prism research-user update alice --email "alice.smith@university.edu"
+prism user update alice --full-name "Dr. Alice Smith"
+prism user update alice --email "alice.smith@university.edu"
 
 # Add/remove groups
-prism research-user update alice --add-groups jupyter-users
-prism research-user update alice --remove-groups docker
+prism user update alice --add-groups jupyter-users
+prism user update alice --remove-groups docker
 
 # Change shell
-prism research-user update alice --shell /bin/zsh
+prism user update alice --shell /bin/zsh
 ```
 
 ### Listing and Inspecting Users
 
 ```bash
 # List all research users in current profile
-prism research-user list
+prism user list
 
 # List with detailed information
-prism research-user list --detailed
+prism user list --detailed
 
 # Show specific user information
-prism research-user show alice
+prism user show alice
 
 # Show user with SSH keys and instance history
-prism research-user show alice --include-keys --include-instances
+prism user show alice --include-keys --include-instances
 ```
 
 #### Example Output
@@ -214,16 +214,16 @@ Research Users (Profile: personal-research)
 
 ```bash
 # Delete user (with confirmation)
-prism research-user delete alice
+prism user delete alice
 
 # Force delete without confirmation
-prism research-user delete alice --force
+prism user delete alice --force
 
 # Delete user and clean up SSH keys
-prism research-user delete alice --cleanup-keys
+prism user delete alice --cleanup-keys
 
 # Delete user but preserve EFS home directory
-prism research-user delete alice --preserve-home
+prism user delete alice --preserve-home
 ```
 
 ## SSH Key Management
@@ -232,45 +232,45 @@ prism research-user delete alice --preserve-home
 
 ```bash
 # Generate Ed25519 key (recommended)
-prism research-user ssh-key generate alice ed25519
+prism user keys generate alice ed25519
 
 # Generate RSA key for compatibility
-prism research-user ssh-key generate alice rsa
+prism user keys generate alice rsa
 
 # Generate with custom comment
-prism research-user ssh-key generate alice ed25519 --comment "alice-laptop-2025"
+prism user keys generate alice ed25519 --comment "alice-laptop-2025"
 ```
 
 ### Key Import and Export
 
 ```bash
 # Import existing public key
-prism research-user ssh-key import alice ~/.ssh/id_rsa.pub
+prism user keys add alice ~/.ssh/id_rsa.pub
 
 # Import with custom comment
-prism research-user ssh-key import alice ~/.ssh/id_rsa.pub --comment "Personal laptop key"
+prism user keys add alice ~/.ssh/id_rsa.pub --comment "Personal laptop key"
 
 # Export all keys for backup
-prism research-user ssh-key export alice --output alice-keys-backup.tar.gz
+prism user ssh-key export alice --output alice-keys-backup.tar.gz
 
 # Export single key
-prism research-user ssh-key export alice --key-id <key-id> --output alice-key.pub
+prism user ssh-key export alice --key-id <key-id> --output alice-key.pub
 ```
 
 ### Key Management
 
 ```bash
 # List all SSH keys for user
-prism research-user ssh-key list alice
+prism user keys list alice
 
 # Show detailed key information
-prism research-user ssh-key show alice <key-id>
+prism user ssh-key show alice <key-id>
 
 # Delete specific key
-prism research-user ssh-key delete alice <key-id>
+prism user keys remove alice <key-id>
 
 # Rotate keys (generate new, deactivate old)
-prism research-user ssh-key rotate alice ed25519
+prism user ssh-key rotate alice ed25519
 ```
 
 #### SSH Key Listing Example
@@ -290,13 +290,13 @@ SSH Keys for alice (Profile: personal-research)
 
 ```bash
 # Generate authorized_keys content for user
-prism research-user ssh-key authorized-keys alice
+prism user ssh-key authorized-keys alice
 
 # Save to file
-prism research-user ssh-key authorized-keys alice > alice_authorized_keys
+prism user ssh-key authorized-keys alice > alice_authorized_keys
 
 # Generate for multiple users
-prism research-user ssh-key authorized-keys alice,bob,carol > team_authorized_keys
+prism user ssh-key authorized-keys alice,bob,carol > team_authorized_keys
 ```
 
 ## EFS Integration
@@ -305,39 +305,39 @@ prism research-user ssh-key authorized-keys alice,bob,carol > team_authorized_ke
 
 ```bash
 # Create EFS volume for research users
-prism volumes create research-home --type efs --performance generalPurpose
+prism volume create research-home --type efs --performance generalPurpose
 
 # Create high-performance EFS for shared data
-prism volumes create shared-datasets --type efs --performance provisioned --throughput 500
+prism volume create shared-datasets --type efs --performance provisioned --throughput 500
 
 # List EFS volumes
-prism volumes list --type efs
+prism volume list --type efs
 ```
 
 ### Home Directory Setup
 
 ```bash
 # Configure research user with EFS home
-prism research-user create alice --efs-volume research-home --efs-mount /efs
+prism user create alice --efs-volume research-home --efs-mount /efs
 
 # Update existing user with EFS
-prism research-user update alice --efs-volume research-home --efs-mount /efs
+prism user update alice --efs-volume research-home --efs-mount /efs
 
 # Create home directory structure
-prism research-user setup-home alice --create-directories projects,scratch,archive
+prism user setup-home alice --create-directories projects,scratch,archive
 ```
 
 ### EFS Mounting and Permissions
 
 ```bash
 # Mount EFS volume to instance
-prism volumes mount research-home my-instance --mount-point /efs
+prism volume mount research-home my-instance --mount-point /efs
 
 # Check mount status
-prism volumes status research-home
+prism volume status research-home
 
 # Set up permissions for research users
-prism research-user setup-efs-permissions alice --volume research-home
+prism user setup-efs-permissions alice --volume research-home
 ```
 
 #### EFS Directory Structure
@@ -370,16 +370,16 @@ prism research-user setup-efs-permissions alice --volume research-home
 
 ```bash
 # Provision research user on existing instance
-prism research-user provision alice --instance my-python-instance
+prism user provision alice --instance my-python-instance
 
 # Provision with custom EFS mount
-prism research-user provision alice --instance my-instance --efs-volume research-data --mount-point /data
+prism user provision alice --instance my-instance --efs-volume research-data --mount-point /data
 
 # Provision multiple users
-prism research-user provision alice,bob,carol --instance shared-instance
+prism user provision alice,bob,carol --instance shared-instance
 
 # Provision with specific SSH user
-prism research-user provision alice --instance my-instance --ssh-user ubuntu --ssh-key ~/.ssh/my-key
+prism user provision alice --instance my-instance --ssh-user ubuntu --ssh-key ~/.ssh/my-key
 ```
 
 ### Instance Launch with Research Users
@@ -399,16 +399,16 @@ prism workspace launch "Python ML" gpu-training --research-user alice --efs-volu
 
 ```bash
 # Check research user status on instance
-prism research-user status alice --instance ml-work
+prism user status alice --instance ml-work
 
 # Monitor provisioning progress
-prism research-user provision-status <job-id>
+prism user provision-status <job-id>
 
 # List all research user instances
-prism research-user instances alice
+prism user instances alice
 
 # Check what instances a user can access
-prism research-user list-access alice
+prism user list-access alice
 ```
 
 #### Status Output Example
@@ -436,15 +436,15 @@ Research User Status: alice on ml-work
 
 ```bash
 # Create team research users
-prism research-user create alice --full-name "Alice Smith" --email "alice@lab.edu"
-prism research-user create bob --full-name "Bob Johnson" --email "bob@lab.edu"
-prism research-user create carol --full-name "Carol Davis" --email "carol@lab.edu"
+prism user create alice --full-name "Alice Smith" --email "alice@lab.edu"
+prism user create bob --full-name "Bob Johnson" --email "bob@lab.edu"
+prism user create carol --full-name "Carol Davis" --email "carol@lab.edu"
 
 # Create shared EFS volume
-prism volumes create team-research --type efs --performance provisioned --throughput 300
+prism volume create team-research --type efs --performance provisioned --throughput 300
 
 # Setup shared directories
-prism research-user setup-collaboration --users alice,bob,carol --volume team-research
+prism user setup-collaboration --users alice,bob,carol --volume team-research
 ```
 
 ### Collaborative Workflows
@@ -489,14 +489,14 @@ ls -la /efs/shared/analysis/
 
 ```bash
 # Create project-specific groups
-prism research-user create-group ml-team --members alice,bob
-prism research-user create-group viz-team --members alice,carol
-prism research-user create-group stats-team --members bob,carol
+prism user create-group ml-team --members alice,bob
+prism user create-group viz-team --members alice,carol
+prism user create-group stats-team --members bob,carol
 
 # Set directory permissions for groups
-prism research-user set-permissions /efs/shared/ml-project --group ml-team --mode 775
-prism research-user set-permissions /efs/shared/visualizations --group viz-team --mode 775
-prism research-user set-permissions /efs/shared/statistics --group stats-team --mode 775
+prism user set-permissions /efs/shared/ml-project --group ml-team --mode 775
+prism user set-permissions /efs/shared/visualizations --group viz-team --mode 775
+prism user set-permissions /efs/shared/statistics --group stats-team --mode 775
 ```
 
 ## Monitoring and Analytics
@@ -505,16 +505,16 @@ prism research-user set-permissions /efs/shared/statistics --group stats-team --
 
 ```bash
 # Show research user activity summary
-prism research-user analytics --profile personal-research
+prism user analytics --profile personal-research
 
 # Show detailed usage for specific user
-prism research-user analytics alice --detailed
+prism user analytics alice --detailed
 
 # Show team usage summary
-prism research-user analytics --users alice,bob,carol --timeframe 30d
+prism user analytics --users alice,bob,carol --timeframe 30d
 
 # Export usage data
-prism research-user analytics alice --export csv --output alice-usage.csv
+prism user analytics alice --export csv --output alice-usage.csv
 ```
 
 #### Analytics Output Example
@@ -539,32 +539,32 @@ Research User Analytics (Last 30 days)
 
 ```bash
 # Check UID/GID allocation status
-prism research-user system-status --uid-allocations
+prism user system-status --uid-allocations
 
 # Check SSH key health
-prism research-user system-status --ssh-keys
+prism user system-status --ssh-keys
 
 # Check EFS integration status
-prism research-user system-status --efs-integration
+prism user system-status --efs-integration
 
 # Full system health check
-prism research-user system-status --full
+prism user system-status --full
 ```
 
 ### Audit and Security Monitoring
 
 ```bash
 # Show recent research user activities
-prism research-user audit-log --recent 24h
+prism user audit-log --recent 24h
 
 # Show specific user's audit trail
-prism research-user audit-log alice --timeframe 7d
+prism user audit-log alice --timeframe 7d
 
 # Show SSH key usage patterns
-prism research-user audit-log --ssh-keys --timeframe 30d
+prism user audit-log --ssh-keys --timeframe 30d
 
 # Export audit logs
-prism research-user audit-log --export json --output audit-2025-09.json
+prism user audit-log --export json --output audit-2025-09.json
 ```
 
 ## Troubleshooting
@@ -577,18 +577,18 @@ prism research-user audit-log --export json --output audit-2025-09.json
 
 ```bash
 # Diagnosis
-prism research-user status alice --instance my-instance
-prism research-user ssh-key list alice
+prism user status alice --instance my-instance
+prism user keys list alice
 
 # Solutions
 # Check if user is provisioned
-prism research-user provision alice --instance my-instance
+prism user provision alice --instance my-instance
 
 # Verify SSH keys are installed
 ssh ubuntu@my-instance "sudo cat /efs/home/alice/.ssh/authorized_keys"
 
 # Re-provision if needed
-prism research-user provision alice --instance my-instance --force
+prism user provision alice --instance my-instance --force
 ```
 
 #### 2. File Permission Issues
@@ -602,7 +602,7 @@ ssh alice@instance "groups"
 
 # Solutions
 # Check if user is in research group
-prism research-user update alice --add-groups research
+prism user update alice --add-groups research
 
 # Fix file permissions
 ssh alice@instance "sudo chgrp research /efs/shared/problematic-file"
@@ -620,13 +620,13 @@ ssh alice@instance "ls -la /efs/"
 
 # Solutions
 # Check EFS mount status
-prism volumes status research-home
+prism volume status research-home
 
 # Remount EFS volume
-prism volumes mount research-home my-instance --mount-point /efs
+prism volume mount research-home my-instance --mount-point /efs
 
 # Fix EFS permissions
-prism research-user setup-efs-permissions alice --volume research-home
+prism user setup-efs-permissions alice --volume research-home
 ```
 
 #### 4. UID Conflicts
@@ -640,29 +640,29 @@ ssh alice@instance2 "id alice"  # Should also be 5001
 
 # Solutions
 # Check UID allocation
-prism research-user show alice --include-uid
+prism user show alice --include-uid
 
 # Re-provision user with correct UID
-prism research-user provision alice --instance instance2 --force
+prism user provision alice --instance instance2 --force
 
 # Clear and regenerate UID cache
-prism research-user system-maintenance --clear-uid-cache
+prism user system-maintenance --clear-uid-cache
 ```
 
 ### Diagnostic Commands
 
 ```bash
 # Comprehensive system diagnostics
-prism research-user diagnose
+prism user diagnose
 
 # Diagnose specific user
-prism research-user diagnose alice
+prism user diagnose alice
 
 # Diagnose specific instance
-prism research-user diagnose --instance my-instance
+prism user diagnose --instance my-instance
 
 # Generate diagnostic report
-prism research-user diagnose --report diagnostic-report.txt
+prism user diagnose --report diagnostic-report.txt
 ```
 
 ### Recovery Procedures
@@ -671,26 +671,26 @@ prism research-user diagnose --report diagnostic-report.txt
 
 ```bash
 # Recreate research user from backup
-prism research-user restore alice --from-backup alice-backup.json
+prism user restore alice --from-backup alice-backup.json
 
 # Recreate with same UID (if known)
-prism research-user create alice --force-uid 5001
+prism user create alice --force-uid 5001
 
 # Restore SSH keys
-prism research-user ssh-key import-backup alice alice-keys-backup.tar.gz
+prism user ssh-key import-backup alice alice-keys-backup.tar.gz
 ```
 
 #### Reset Research User System
 
 ```bash
 # Clear all research user data (DESTRUCTIVE)
-prism research-user system-reset --confirm
+prism user system-reset --confirm
 
 # Reset specific profile
-prism research-user system-reset --profile personal-research --confirm
+prism user system-reset --profile personal-research --confirm
 
 # Reset UID allocations only
-prism research-user system-reset --uid-allocations --confirm
+prism user system-reset --uid-allocations --confirm
 ```
 
 ## Security Best Practices
@@ -699,18 +699,18 @@ prism research-user system-reset --uid-allocations --confirm
 
 1. **Use Ed25519 Keys**: Prefer Ed25519 over RSA for new key generation
    ```bash
-   prism research-user ssh-key generate alice ed25519
+   prism user keys generate alice ed25519
    ```
 
 2. **Regular Key Rotation**: Rotate SSH keys periodically
    ```bash
    # Monthly key rotation
-   prism research-user ssh-key rotate alice ed25519 --deactivate-old-after 30d
+   prism user ssh-key rotate alice ed25519 --deactivate-old-after 30d
    ```
 
 3. **Monitor Key Usage**: Track SSH key usage patterns
    ```bash
-   prism research-user audit-log alice --ssh-keys --timeframe 7d
+   prism user audit-log alice --ssh-keys --timeframe 7d
    ```
 
 ### Access Control
@@ -718,24 +718,24 @@ prism research-user system-reset --uid-allocations --confirm
 1. **Principle of Least Privilege**: Only grant necessary permissions
    ```bash
    # Remove docker access if not needed
-   prism research-user update alice --remove-groups docker
+   prism user update alice --remove-groups docker
    ```
 
 2. **Regular Access Reviews**: Review user permissions quarterly
    ```bash
-   prism research-user list --detailed --include-permissions
+   prism user list --detailed --include-permissions
    ```
 
 3. **Group-Based Permissions**: Use groups for shared access
    ```bash
-   prism research-user create-group project-alpha --members alice,bob
+   prism user create-group project-alpha --members alice,bob
    ```
 
 ### Data Security
 
 1. **EFS Encryption**: Use encrypted EFS volumes
    ```bash
-   prism volumes create secure-research --type efs --encrypted
+   prism volume create secure-research --type efs --encrypted
    ```
 
 2. **Home Directory Isolation**: Ensure proper home directory permissions
@@ -761,12 +761,12 @@ prism research-user system-reset --uid-allocations --confirm
 
 2. **Regular Security Scans**: Check for security issues
    ```bash
-   prism research-user security-scan --profile personal-research
+   prism user security-scan --profile personal-research
    ```
 
 3. **Compliance Reporting**: Generate compliance reports
    ```bash
-   prism research-user compliance-report --format pdf --output compliance-2025-Q3.pdf
+   prism user compliance-report --format pdf --output compliance-2025-Q3.pdf
    ```
 
 ## Institutional Deployment
@@ -777,25 +777,25 @@ prism research-user system-reset --uid-allocations --confirm
 
 ```bash
 # Batch user creation from CSV
-prism research-user batch-create --from-csv students-cs501.csv
+prism user batch-create --from-csv students-cs501.csv
 
 # Template optimization for education
-prism research-user configure-education --class cs501 --template "Python ML" --users-from-csv students.csv
+prism user configure-education --class cs501 --template "Python ML" --users-from-csv students.csv
 
 # Automated EFS setup for classes
-prism research-user setup-class-storage cs501 --volume-size 1TB --shared-quota 100GB-per-user
+prism user setup-class-storage cs501 --volume-size 1TB --shared-quota 100GB-per-user
 ```
 
 #### Research Institution (500+ Users)
 
 ```bash
 # Department-based organization
-prism research-user create-department computer-science --quota 10TB
-prism research-user create-department biology --quota 25TB
-prism research-user create-department physics --quota 15TB
+prism user create-department computer-science --quota 10TB
+prism user create-department biology --quota 25TB
+prism user create-department physics --quota 15TB
 
 # Automated provisioning pipeline
-prism research-user setup-auto-provisioning --ldap-integration --department-quotas
+prism user setup-auto-provisioning --ldap-integration --department-quotas
 ```
 
 ### Integration with External Systems
@@ -804,23 +804,23 @@ prism research-user setup-auto-provisioning --ldap-integration --department-quot
 
 ```bash
 # Configure LDAP authentication
-prism research-user configure-ldap --server ldap.university.edu --base-dn "ou=users,dc=university,dc=edu"
+prism user configure-ldap --server ldap.university.edu --base-dn "ou=users,dc=university,dc=edu"
 
 # Sync users from LDAP
-prism research-user ldap-sync --department computer-science
+prism user ldap-sync --department computer-science
 
 # Map LDAP groups to research user groups
-prism research-user map-ldap-groups "cn=CS Students,ou=groups,dc=university,dc=edu" students
+prism user map-ldap-groups "cn=CS Students,ou=groups,dc=university,dc=edu" students
 ```
 
 #### Single Sign-On (SSO) Integration
 
 ```bash
 # Configure SAML SSO
-prism research-user configure-sso --provider saml --metadata-url https://sso.university.edu/metadata
+prism user configure-sso --provider saml --metadata-url https://sso.university.edu/metadata
 
 # Configure OAuth integration
-prism research-user configure-sso --provider oauth --client-id university-cws --discovery-url https://oauth.university.edu/.well-known
+prism user configure-sso --provider oauth --client-id university-cws --discovery-url https://oauth.university.edu/.well-known
 ```
 
 ### Policy Management
@@ -829,26 +829,26 @@ prism research-user configure-sso --provider oauth --client-id university-cws --
 
 ```bash
 # Create policy templates for different user types
-prism research-user create-policy undergraduate --max-instances 2 --max-storage 10GB --templates "Python ML,R Research"
-prism research-user create-policy graduate --max-instances 5 --max-storage 100GB --templates "*"
-prism research-user create-policy faculty --max-instances unlimited --max-storage 1TB --templates "*"
+prism user create-policy undergraduate --max-instances 2 --max-storage 10GB --templates "Python ML,R Research"
+prism user create-policy graduate --max-instances 5 --max-storage 100GB --templates "*"
+prism user create-policy faculty --max-instances unlimited --max-storage 1TB --templates "*"
 
 # Apply policies to users
-prism research-user apply-policy alice undergraduate
-prism research-user apply-policy bob graduate
+prism user apply-policy alice undergraduate
+prism user apply-policy bob graduate
 ```
 
 #### Compliance and Governance
 
 ```bash
 # Enable data residency controls
-prism research-user configure-compliance --data-residency US --encryption required
+prism user configure-compliance --data-residency US --encryption required
 
 # Set retention policies
-prism research-user configure-retention --inactive-users 365d --archive-data 7y
+prism user configure-retention --inactive-users 365d --archive-data 7y
 
 # Configure audit requirements
-prism research-user configure-audit --level comprehensive --retention 10y --export-format syslog
+prism user configure-audit --level comprehensive --retention 10y --export-format syslog
 ```
 
 ## Advanced Configuration
@@ -951,26 +951,26 @@ prism plugin configure research-user-ldap-sync --server ldap.university.edu
 
 ```bash
 # Backup all research user configurations
-prism research-user backup --profile personal-research --output research-users-backup.tar.gz
+prism user backup --profile personal-research --output research-users-backup.tar.gz
 
 # Backup SSH keys
-prism research-user backup-ssh-keys --profile personal-research --output ssh-keys-backup.tar.gz
+prism user backup-ssh-keys --profile personal-research --output ssh-keys-backup.tar.gz
 
 # Backup EFS data
-prism volumes snapshot research-home --description "Weekly backup $(date +%Y-%m-%d)"
+prism volume snapshot research-home --description "Weekly backup $(date +%Y-%m-%d)"
 ```
 
 #### Recovery Procedures
 
 ```bash
 # Restore research users from backup
-prism research-user restore --from-backup research-users-backup.tar.gz
+prism user restore --from-backup research-users-backup.tar.gz
 
 # Restore SSH keys
-prism research-user restore-ssh-keys --from-backup ssh-keys-backup.tar.gz
+prism user restore-ssh-keys --from-backup ssh-keys-backup.tar.gz
 
 # Restore EFS from snapshot
-prism volumes restore research-home --from-snapshot snap-1234567890abcdef0
+prism volume restore research-home --from-snapshot snap-1234567890abcdef0
 ```
 
 ## Conclusion

--- a/docs/admin-guides/RESEARCH_USER_MANAGEMENT_GUIDE.md
+++ b/docs/admin-guides/RESEARCH_USER_MANAGEMENT_GUIDE.md
@@ -987,9 +987,9 @@ Research User Management in Prism v0.5.0 provides a comprehensive foundation for
 The research user system transforms Prism from a single-user tool into a collaborative research platform while maintaining the simplicity and flexibility that makes Prism powerful.
 
 For additional support:
-- 📚 **Technical Documentation**: [Phase 5A Research User Architecture](PHASE_5A_RESEARCH_USER_ARCHITECTURE.md)
-- 👥 **User Guide**: [Research Users User Guide](USER_GUIDE_RESEARCH_USERS.md)
-- 🏗️ **Architecture Guide**: [Dual User Architecture](DUAL_USER_ARCHITECTURE.md)
+- 📚 **Technical Documentation**: Phase 5A Research User Architecture
+- 👥 **User Guide**: Research Users User Guide
+- 🏗️ **Architecture Guide**: Dual User Architecture
 - 🐛 **Support**: [GitHub Issues](https://github.com/scttfrdmn/prism/issues)
 
 ---

--- a/docs/admin-guides/SECURITY_HARDENING_GUIDE.md
+++ b/docs/admin-guides/SECURITY_HARDENING_GUIDE.md
@@ -392,10 +392,10 @@ export PRISM_EMAIL_ALERTS="security@example.com"
 
 ## 📚 Additional Resources
 
-- [Prism Security Architecture](./SECURITY_ARCHITECTURE.md)
-- [API Security Reference](./API_SECURITY.md)
-- [Compliance Checklist](./COMPLIANCE_CHECKLIST.md)
-- [Incident Response Playbook](./INCIDENT_RESPONSE.md)
+- Prism Security Architecture
+- API Security Reference
+- Compliance Checklist
+- Incident Response Playbook
 
 ## 🆘 Support and Troubleshooting
 

--- a/docs/architecture/WEB_SERVICE_IMPLEMENTATION.md
+++ b/docs/architecture/WEB_SERVICE_IMPLEMENTATION.md
@@ -270,7 +270,7 @@ ConnectionConfig {
 
 ## Testing
 
-See [WEB_SERVICE_TESTING.md](../WEB_SERVICE_TESTING.md) for comprehensive testing procedures.
+See WEB_SERVICE_TESTING.md for comprehensive testing procedures.
 
 Quick test:
 ```bash

--- a/docs/development/COMMUNITY_TEMPLATE_GUIDE.md
+++ b/docs/development/COMMUNITY_TEMPLATE_GUIDE.md
@@ -454,7 +454,7 @@ packages:
 - Adding specific packages to general-purpose base
 - Creating template family (basic → intermediate → advanced)
 
-See [Template Inheritance Documentation](../../templates/README.md#inheritance) for details.
+See Template Inheritance Documentation for details.
 
 ---
 
@@ -602,8 +602,8 @@ Ready to contribute? Great!
 
 ## Related Documentation
 
-- [Template README](../../templates/README.md) - Template structure and inheritance
-- [Template Review Checklist](TEMPLATE_REVIEW_CHECKLIST.md) - Maintainer review guide
+- Template README - Template structure and inheritance
+- Template Review Checklist - Maintainer review guide
 - [AWS Setup Guide](../user-guides/AWS_SETUP_GUIDE.md) - Setting up AWS access
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ brew install scttfrdmn/tap/prism
 aws login
 
 # Add a Prism profile
-prism profile add
+prism profiles add
 
 # Launch a research environment
 prism workspace launch python-ml my-project

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -774,7 +774,7 @@ Want to add a new plugin?
    - Test template
    - Documentation updates
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
+See CONTRIBUTING.md for details.
 
 ---
 

--- a/docs/prism-iam-policy-optional.json
+++ b/docs/prism-iam-policy-optional.json
@@ -1,0 +1,30 @@
+{
+  "_comment": "OPTIONAL Prism permissions. Attach IN ADDITION to prism-iam-policy.json only if you use the corresponding features. Prism degrades gracefully without these: the feature is simply unavailable, not broken.",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ComplianceReporting",
+      "Effect": "Allow",
+      "Action": [
+        "organizations:ListPolicies",
+        "organizations:DescribeOrganization",
+        "artifact:ListReports",
+        "artifact:GetReport"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TemplateMarketplaceRegistry",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/prism-*"
+    }
+  ]
+}

--- a/docs/prism-iam-policy.json
+++ b/docs/prism-iam-policy.json
@@ -19,6 +19,9 @@
         "ec2:DeleteVolume",
         "ec2:AttachVolume",
         "ec2:DetachVolume",
+        "ec2:ModifyVolume",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:GetConsoleOutput",
         "ec2:CreateTags",
         "ec2:DescribeTags"
       ],
@@ -31,6 +34,7 @@
         "ec2:DescribeVpcs",
         "ec2:DescribeSubnets",
         "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
         "ec2:CreateSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",
@@ -49,6 +53,38 @@
       "Resource": "*"
     },
     {
+      "Sid": "EC2SpotPricing",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeSpotPriceHistory"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EC2SnapshotAndImage",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateImage",
+        "ec2:RegisterImage",
+        "ec2:DeregisterImage",
+        "ec2:ModifyImageAttribute",
+        "ec2:CreateSnapshot",
+        "ec2:DeleteSnapshot",
+        "ec2:DescribeSnapshots"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EC2CapacityReservations",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateCapacityReservation",
+        "ec2:DescribeCapacityReservations",
+        "ec2:CancelCapacityReservation"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "EFSVolumeManagement",
       "Effect": "Allow",
       "Action": [
@@ -62,6 +98,41 @@
         "elasticfilesystem:DescribeTags"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "FSxLustreManagement",
+      "Effect": "Allow",
+      "Action": [
+        "fsx:CreateFileSystem",
+        "fsx:DeleteFileSystem",
+        "fsx:UpdateFileSystem",
+        "fsx:DescribeFileSystems",
+        "fsx:TagResource",
+        "fsx:ListTagsForResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3WorkspaceData",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::prism-temp-*",
+        "arn:aws:s3:::prism-temp-*/*",
+        "arn:aws:s3:::prism-backups-*",
+        "arn:aws:s3:::prism-backups-*/*",
+        "arn:aws:s3:::prism-efs-*",
+        "arn:aws:s3:::prism-efs-*/*",
+        "arn:aws:s3:::prism-transfer*",
+        "arn:aws:s3:::prism-transfer*/*"
+      ]
     },
     {
       "Sid": "IAMInstanceProfileManagement",
@@ -92,6 +163,42 @@
         "ssm:ListCommands",
         "ssm:ListCommandInvocations",
         "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ComputePricing",
+      "Effect": "Allow",
+      "Action": [
+        "pricing:GetProducts"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CostAndUsageReporting",
+      "Effect": "Allow",
+      "Action": [
+        "ce:GetCostAndUsage",
+        "ce:GetCostForecast"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchMetrics",
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ServiceQuotaPreflight",
+      "Effect": "Allow",
+      "Action": [
+        "servicequotas:GetServiceQuota",
+        "servicequotas:ListServiceQuotas"
       ],
       "Resource": "*"
     },

--- a/docs/prism-instance-role-policy.json
+++ b/docs/prism-instance-role-policy.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "The INSTANCE-SIDE role Prism attaches to each workspace (Prism-Instance-Profile-Role), distinct from the user/daemon policy in prism-iam-policy.json. Prism AUTO-CREATES this on first launch when the user policy grants the IAM* actions. It combines the AWS-managed AmazonSSMManagedInstanceCore policy with the inline policy below. Documented here so it can be pre-provisioned by an administrator when end users lack IAM CreateRole permission. Trust policy: ec2.amazonaws.com may sts:AssumeRole.",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AutonomousIdleDetection",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DescribeTags",
+        "ec2:DescribeInstances",
+        "ec2:StopInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/docs/user-guides/AMI_BEST_PRACTICES.md
+++ b/docs/user-guides/AMI_BEST_PRACTICES.md
@@ -961,4 +961,4 @@ Before creating and sharing an AMI:
 
 - [Custom AMI Workflow](CUSTOM_AMI_WORKFLOW.md) - Step-by-step guide
 - [Multi-User Instance Setup](MULTI_USER_INSTANCE_SETUP.md) - Team collaboration
-- [Cost Management](COST_MANAGEMENT.md) - Optimizing costs
+- Cost Management - Optimizing costs

--- a/docs/user-guides/AWS_SETUP_GUIDE.md
+++ b/docs/user-guides/AWS_SETUP_GUIDE.md
@@ -56,13 +56,13 @@ brew install awscli
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip && sudo ./aws/install
 
-# Verify (must be v2.32.0+ for aws login)
+# Verify (must be v2.32+ for aws login)
 aws --version
 ```
 
 ### Option A: Browser-based login (recommended)
 
-`aws login` authenticates via your browser using IAM user or federated identity credentials — no key management required. Requires AWS CLI v2.32.0+.
+`aws login` authenticates via your browser using IAM user or federated identity credentials — no key management required. Requires AWS CLI v2.32+.
 
 ```bash
 # Authenticate (opens browser)

--- a/docs/user-guides/CLI_REFERENCE.md
+++ b/docs/user-guides/CLI_REFERENCE.md
@@ -105,10 +105,10 @@ prism templates info python-ml
 Profiles map a name to an AWS credential profile and region. The daemon uses the active profile for all AWS operations.
 
 ```bash
-prism profile add                            # Interactive: add a new profile
-prism profile list                           # Show all profiles (active profile marked)
-prism profile switch <name>                  # Make a profile active
-prism profile delete <name>                  # Remove a profile
+prism profiles add                            # Interactive: add a new profile
+prism profiles list                           # Show all profiles (active profile marked)
+prism profiles switch <name>                  # Make a profile active
+prism profiles delete <name>                  # Remove a profile
 ```
 
 ---

--- a/docs/user-guides/CUSTOM_AMI_WORKFLOW.md
+++ b/docs/user-guides/CUSTOM_AMI_WORKFLOW.md
@@ -494,4 +494,4 @@ prism ami delete ami-old123def456
 
 - [Getting Started](QUICK_START.md) - Core workflow overview
 - [R Getting Started](R_GETTING_STARTED.md) - R-specific guidance including AMI creation
-- [Cost Management](COST_MANAGEMENT.md) - Optimizing AMI storage costs
+- Cost Management - Optimizing AMI storage costs

--- a/docs/user-guides/GUI_NAVIGATION_GUIDE.md
+++ b/docs/user-guides/GUI_NAVIGATION_GUIDE.md
@@ -189,7 +189,7 @@ Planned improvements for Settings navigation:
 
 - [GUI Architecture](../architecture/GUI_ARCHITECTURE.md)
 - 
-- [GUI UX Design Review](../architecture/GUI_UX_DESIGN_REVIEW.md)
+- GUI UX Design Review
 - 
 
 ---

--- a/docs/user-guides/INVITATION_USER_GUIDE.md
+++ b/docs/user-guides/INVITATION_USER_GUIDE.md
@@ -627,8 +627,8 @@ prism invitation shared create "ICML 2026 ML Workshop" \
 
 - [Getting Started Guide](QUICK_START.md)
 - [Research Users Guide](USER_GUIDE_RESEARCH_USERS.md)
-- [Project Management Guide](../admin-guides/PROJECT_MANAGEMENT_GUIDE.md)
-- [API Documentation](../development/API_INVITATION_REFERENCE.md)
+- Project Management Guide
+- API Documentation
 
 ---
 

--- a/docs/user-guides/LINUX_INSTALLATION.md
+++ b/docs/user-guides/LINUX_INSTALLATION.md
@@ -288,7 +288,7 @@ aws sts get-caller-identity
 
 # Check Prism AWS config
 prism profiles current
-prism daemon status
+prism admin daemon status
 ```
 
 #### Permission Errors

--- a/docs/user-guides/QUICK_START.md
+++ b/docs/user-guides/QUICK_START.md
@@ -47,7 +47,7 @@ aws sts get-caller-identity
 **Step 2 — Add a Prism profile**:
 
 ```bash
-prism profile add
+prism profiles add
 ```
 
 This interactive wizard links a Prism profile to your AWS credentials and default region. You only need to do this once.
@@ -56,7 +56,7 @@ This interactive wizard links a Prism profile to your AWS credentials and defaul
 
 ## 3. First-time wizard (optional)
 
-If this is your first time running Prism, `prism init` covers credential validation, profile creation, and a test launch in one flow:
+If this is your first time running Prism, `prism init` validates your AWS credentials, walks you through picking a template and size, and launches your first workspace — all in one guided flow:
 
 ```bash
 prism init

--- a/docs/user-guides/TERMINOLOGY_GLOSSARY.md
+++ b/docs/user-guides/TERMINOLOGY_GLOSSARY.md
@@ -185,7 +185,7 @@ Some terms are inherently technical and remain AWS-specific in Prism:
 **How they relate**:
 ```bash
 # Prism profile references an AWS profile
-prism profile create research \
+prism profiles add personal research \
   --aws-profile my-aws-creds \
   --region us-west-2
 ```

--- a/docs/user-guides/TERMINOLOGY_GLOSSARY.md
+++ b/docs/user-guides/TERMINOLOGY_GLOSSARY.md
@@ -332,4 +332,4 @@ aws ec2 describe-instances --instance-ids i-abc123456789
 - [Issue #15 - Instances → Workspaces Rename](https://github.com/scttfrdmn/prism/issues/15)
 - [Issue #66 - Storage Terminology Simplification](https://github.com/scttfrdmn/prism/issues/66)
 - [Design Principles](../DESIGN_PRINCIPLES.md)
-- [User Requirements](../USER_REQUIREMENTS.md)
+- User Requirements

--- a/docs/user-guides/USER_GUIDE_RESEARCH_USERS.md
+++ b/docs/user-guides/USER_GUIDE_RESEARCH_USERS.md
@@ -74,7 +74,7 @@ Instance Setup:
 prism user create alice
 
 # Generate SSH keys automatically
-prism user ssh-key generate alice ed25519
+prism user keys generate alice ed25519
 ```
 
 ### 2. Launch Instances with Research Users
@@ -154,7 +154,7 @@ One set of SSH keys works everywhere:
 
 ```bash
 # Generate keys once
-prism user ssh-key generate alice ed25519
+prism user keys generate alice ed25519
 
 # Use same key for all instances
 ssh alice@python-instance    # Works
@@ -199,27 +199,27 @@ ssh alice@rocky-instance     # Works
 
 ```bash
 # Generate Ed25519 key (recommended)
-prism user ssh-key generate alice ed25519
+prism user keys generate alice ed25519
 
 # Or generate RSA key for compatibility
-prism user ssh-key generate alice rsa
+prism user keys generate alice rsa
 ```
 
 ### Import Existing Keys
 
 ```bash
 # Import your existing public key
-prism user ssh-key import alice ~/.ssh/id_rsa.pub "My laptop key"
+prism user keys add alice ~/.ssh/id_rsa.pub "My laptop key"
 ```
 
 ### List and Manage Keys
 
 ```bash
 # List all SSH keys
-prism user ssh-key list alice
+prism user keys list alice
 
 # Delete a key
-prism user ssh-key delete alice key-id
+prism user keys remove alice key-id
 ```
 
 ## Working with Templates
@@ -296,11 +296,11 @@ research_user:
 2. **Share EFS volumes across instances**:
    ```bash
    # Create shared EFS volume
-   prism volumes create team-research-data
+   prism volume create team-research-data
 
    # Mount on all instances
-   prism volumes mount team-research-data alice-instance
-   prism volumes mount team-research-data bob-instance
+   prism volume mount team-research-data alice-instance
+   prism volume mount team-research-data bob-instance
    ```
 
 3. **Collaborate with consistent permissions**:
@@ -376,10 +376,10 @@ tar -xzf my-research-backup.tar.gz
 
 ```bash
 # Import your existing SSH key
-prism user ssh-key import alice ~/.ssh/id_rsa.pub "Migrated key"
+prism user keys add alice ~/.ssh/id_rsa.pub "Migrated key"
 
 # Or generate new keys and update GitHub/servers
-prism user ssh-key generate alice ed25519
+prism user keys generate alice ed25519
 cat /efs/home/alice/.ssh/id_ed25519.pub  # Add to GitHub, servers
 ```
 
@@ -390,7 +390,7 @@ cat /efs/home/alice/.ssh/id_ed25519.pub  # Add to GitHub, servers
 **Q: I can't SSH into my instance with my research user**
 ```bash
 # Check SSH key is properly configured
-prism user ssh-key list alice
+prism user keys list alice
 
 # Verify user was provisioned
 prism user status alice --instance my-instance
@@ -408,7 +408,7 @@ ssh alice@my-instance "mount | grep efs"
 ssh alice@my-instance "ls -la /efs/home/"
 
 # Check if EFS volume is mounted
-prism volumes list
+prism volume list
 ```
 
 **Q: File permissions are wrong**

--- a/docs/user-guides/ZERO_SETUP_GUIDE.md
+++ b/docs/user-guides/ZERO_SETUP_GUIDE.md
@@ -31,7 +31,7 @@ The Prism daemon (`prismd`) starts automatically when needed:
 ```bash
 prism workspace launch template my-instance
 # ✅ Daemon starts automatically if not running
-# ✅ No need for: prism daemon start
+# ✅ No need for: prism admin daemon start
 # ✅ No systemd/launchd configuration needed
 ```
 

--- a/docs/user-guides/ZERO_SETUP_GUIDE.md
+++ b/docs/user-guides/ZERO_SETUP_GUIDE.md
@@ -334,7 +334,7 @@ You should be doing research, not configuring infrastructure. Prism makes that p
 
 ## 📚 Learn More
 
-- [Quick Start Guide](../README.md#-quick-start---zero-setup-experience)
+- Quick Start Guide
 - [Administrator Guide](../admin-guides/ADMINISTRATOR_GUIDE.md) (for manual AWS configuration)
 - [Template Format](TEMPLATE_FORMAT.md) (creating custom templates)
 - [Getting Started Guide](QUICK_START.md) (complete CLI reference)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Prism
-site_url: https://prismcloud.io
+site_url: https://prismcloud.host
 site_description: Cloud research workstations for scientists — launch in seconds, not hours.
 site_author: Scott Friedman
 
@@ -123,34 +123,93 @@ extra:
 nav:
   - Home: index.md
 
-  - Getting Started: user-guides/QUICK_START.md
+  - Getting Started:
+    - Quick Start: user-guides/QUICK_START.md
+    - Zero-Setup Guide: user-guides/ZERO_SETUP_GUIDE.md
+    - AWS Setup: user-guides/AWS_SETUP_GUIDE.md
+    - macOS Install: user-guides/MACOS_INSTALLATION.md
+    - Linux Install: user-guides/LINUX_INSTALLATION.md
+    - Windows Install: user-guides/WINDOWS_INSTALLATION.md
+    - Terminology: user-guides/TERMINOLOGY_GLOSSARY.md
 
   - User Guide:
     - CLI Reference: user-guides/CLI_REFERENCE.md
     - GUI Guide: user-guides/GUI_USER_GUIDE.md
+    - GUI Navigation: user-guides/GUI_NAVIGATION_GUIDE.md
     - Workspace Lifecycle: user-guides/WORKSPACE_LIFECYCLE.md
     - Templates: user-guides/TEMPLATE_FORMAT.md
     - Templates (Advanced): user-guides/TEMPLATE_FORMAT_ADVANCED.md
+    - Conda Package Manager: user-guides/CONDA_PACKAGE_MANAGER.md
     - Profiles & Credentials: user-guides/MULTI_PROFILE_GUIDE.md
+    - Custom AMI Workflow: user-guides/CUSTOM_AMI_WORKFLOW.md
+    - AMI Best Practices: user-guides/AMI_BEST_PRACTICES.md
+    - Web Services: user-guides/WEB_SERVICES_INTEGRATION_GUIDE.md
+    - Research Users: user-guides/USER_GUIDE_RESEARCH_USERS.md
+    - Multi-User Instances: user-guides/MULTI_USER_INSTANCE_SETUP.md
     - Courses: user-guides/COURSES_GUIDE.md
     - Workshops: user-guides/WORKSHOPS_GUIDE.md
     - Approvals: user-guides/APPROVALS_GUIDE.md
     - Invitations: user-guides/INVITATION_USER_GUIDE.md
+    - Collaboration Quickstart: user-guides/COLLABORATION_QUICKSTART.md
+    - Marketplace: user-guides/TEMPLATE_MARKETPLACE_USER_GUIDE.md
     - Troubleshooting: user-guides/TROUBLESHOOTING.md
+    - GUI Troubleshooting: user-guides/GUI_TROUBLESHOOTING.md
+
+  - R / RStudio:
+    - Getting Started with R: user-guides/R_GETTING_STARTED.md
+    - R Research Template: user-guides/R_RESEARCH_TEMPLATE_GUIDE.md
+
+  - Education:
+    - School Pilot Quickstart: user-guides/SCHOOL_PILOT_QUICKSTART.md
 
   - Administrator Guide:
     - Overview: admin-guides/ADMINISTRATOR_GUIDE.md
     - IAM & AWS Permissions: admin-guides/AWS_IAM_PERMISSIONS.md
+    - AWS Quota Management: admin-guides/AWS_QUOTA_MANAGEMENT.md
     - Security Hardening: admin-guides/SECURITY_HARDENING_GUIDE.md
     - Template Policy: admin-guides/TEMPLATE_POLICY_FRAMEWORK.md
+    - Policy Examples: admin-guides/BASIC_POLICY_EXAMPLES.md
     - Research User Management: admin-guides/RESEARCH_USER_MANAGEMENT_GUIDE.md
+    - Profile Export/Import: admin-guides/PROFILE_EXPORT_IMPORT.md
+    - Invitations (Batch): admin-guides/BATCH_INVITATION_GUIDE.md
+    - Compliance Matrix: admin-guides/COMPLIANCE_MATRIX.md
+    - NIST 800-171: admin-guides/NIST_800_171_COMPLIANCE.md
+    - Compliance Disclaimer: admin-guides/COMPLIANCE_DISCLAIMER.md
+
+  - Concepts:
+    - Design Principles: DESIGN_PRINCIPLES.md
+    - Budget Philosophy: BUDGET_PHILOSOPHY.md
+    - Budget Banking: BUDGET_BANKING_PHILOSOPHY.md
+    - Resource Tagging: RESOURCE_TAGGING.md
+    - Template File Provisioning: TEMPLATE_FILE_PROVISIONING.md
+    - Plugins: plugins.md
 
   - Architecture:
     - API Reference: architecture/DAEMON_API_REFERENCE.md
+    - API Authentication: architecture/API_AUTHENTICATION.md
     - spored Daemon: architecture/SPORED_DAEMON.md
     - Idle Detection: architecture/AUTONOMOUS_IDLE_DETECTION.md
+    - Budget Engine: architecture/BUDGET_ENGINE_ARCHITECTURE.md
     - GUI Architecture: architecture/GUI_ARCHITECTURE.md
     - SSH Keys: architecture/ARCHITECTURE_SSH_KEYS.md
     - Research Users: architecture/RESEARCH_USER_ARCHITECTURE.md
+    - Plugin Architecture: architecture/PLUGIN_ARCHITECTURE.md
+    - Web Services: architecture/WEB_SERVICE_IMPLEMENTATION.md
+    - NICE DCV: architecture/NICE_DCV_ARCHITECTURE.md
 
+  - Scenarios:
+    - Solo Researcher: USER_SCENARIOS/01_SOLO_RESEARCHER_WALKTHROUGH.md
+    - Lab Environment: USER_SCENARIOS/02_LAB_ENVIRONMENT_WALKTHROUGH.md
+    - University Class: USER_SCENARIOS/03_UNIVERSITY_CLASS_WALKTHROUGH.md
+    - Conference Workshop: USER_SCENARIOS/04_CONFERENCE_WORKSHOP_WALKTHROUGH.md
+    - Cross-Institutional: USER_SCENARIOS/05_CROSS_INSTITUTIONAL_COLLABORATION_WALKTHROUGH.md
+    - NIH CUI Compliance: USER_SCENARIOS/06_NIH_RESEARCHER_CUI_COMPLIANCE.md
+    - NIH HIPAA Compliance: USER_SCENARIOS/07_NIH_RESEARCHER_PHI_HIPAA_COMPLIANCE.md
+    - Institutional IT: USER_SCENARIOS/08_INSTITUTIONAL_RESEARCH_IT_WALKTHROUGH.md
+
+  - Contributing:
+    - Community Templates: development/COMMUNITY_TEMPLATE_GUIDE.md
+    - Template Design Guidelines: development/TEMPLATE_DESIGN_GUIDELINES.md
+
+  - Roadmap: ROADMAP.md
   - Release Notes: releases/RELEASE_NOTES.md


### PR DESCRIPTION
## Summary

**Phase 2** of the documentation overhaul: correctness. Makes the docs describe what the code actually does, fixes the getting-started path, corrects the IAM policy, rebuilds the nav as the source of truth, and migrates the public domain to **prismcloud.host**. Three commits.

`mkdocs build --strict` now passes with **zero warnings** (was 47).

## IAM (2a) — matches what the code actually calls

The documented policy only covered ec2/efs/iam/ssm/sts, but the code calls ~10 more services. Corrected:

- **`docs/prism-iam-policy.json`** — added `pricing:GetProducts`, `ce:GetCostAndUsage`/`GetCostForecast`, `ec2:DescribeSpotPriceHistory`, EC2 snapshot+image (`CreateImage`/`RegisterImage`/`DeregisterImage`/`ModifyImageAttribute`/`Create`/`Delete`/`DescribeSnapshot`), EC2 capacity reservations, `ModifyVolume`/`ModifyInstanceAttribute`/`GetConsoleOutput`/`DescribeRouteTables`, CloudWatch metrics, Service Quotas, S3 (scoped to `prism-temp-*`/`prism-backups-*`/`prism-efs-*`/`prism-transfer*`), FSx.
- **`docs/prism-iam-policy-optional.json`** (new) — compliance (`organizations`/`artifact`) + marketplace (`dynamodb` on `prism-*`).
- **`docs/prism-instance-role-policy.json`** (new) — documents the auto-created `Prism-Instance-Profile-Role` (SSM core + inline EC2 self-mgmt) with the spored S3/Route53 known-limitation note.
- **`AWS_IAM_PERMISSIONS.md`** — rewritten around the two-policy model, per-service rationale, tiers.

## Command drift + install (2a/2b) — verified against v0.36.1 `--help`

- README quickstart taught `prism launch/connect/list/stop/…` → now `prism workspace …`; `prism doctor` (doesn't exist) → `prism admin daemon status`.
- `prism profile` → `prism profiles`; `research-user` → `user`; `volumes` → `volume`; `user ssh-key import/delete` → `user keys add/remove`.
- INSTALL.md: dropped "v0.5.4" title, `prism daemon` → `prism admin daemon`, leads with `aws login`, fixed broken links to AWS_SETUP_GUIDE/TROUBLESHOOTING, dead `CLOUDWORKSTATION_DEV` → `PRISM_DEV`, `cws` → `prism`.
- README: replaced stale hardcoded v0.5.11 download URLs (would 404) with releases-page guidance; retired the frozen "Version History" block → CHANGELOG pointer.

## Nav + domain (2c)

- Rebuilt `mkdocs.yml` nav to publish the ~30 KEEP orphans in a coherent IA — nothing orphaned.
- Migrated `prismcloud.io` → **prismcloud.host** (site_url, CNAME, README).
- Neutralized 47 dangling intra-doc links (deleted/never-existent targets) across 20 files.

## Deferred to Phase 3 (rewrite)

Fictional `prism user ssh-key {export,show,rotate,authorized-keys}` usages remain in RESEARCH_USER_MANAGEMENT_GUIDE (a rewrite candidate — those subcommands don't exist). VISION/ROADMAP staleness. The 15 MERGE + 11 REWRITE files.