### PR TITLE
docs: tighten the getting-started flow (Phase 4)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,8 +68,8 @@ brew install scttfrdmn/tap/prism
 # Authenticate with AWS (browser-based, no keys needed)
 aws login
 
-# Add a Prism profile
-prism profiles add
+# Add a Prism profile (interactive)
+prism profiles setup
 
 # Launch a research environment
 prism workspace launch python-ml my-project
@@ -102,23 +102,19 @@ prism workspace connect my-project
   <h2 id="downloads-heading">Downloads</h2>
   <div class="downloads-grid">
     <article class="download-card">
-      <strong> macOS Apple Silicon</strong>
-      <a href="https://github.com/scttfrdmn/prism/releases/latest/download/prism-darwin-arm64.tar.gz" class="btn-download">Download</a>
-    </article>
-    <article class="download-card">
-      <strong> macOS Intel</strong>
-      <a href="https://github.com/scttfrdmn/prism/releases/latest/download/prism-darwin-amd64.tar.gz" class="btn-download">Download</a>
+      <strong><span aria-hidden="true">🍎</span> macOS</strong>
+      <span>Homebrew: <code>brew install scttfrdmn/tap/prism</code>, or the <code>.dmg</code> from Releases.</span>
     </article>
     <article class="download-card">
       <strong><span aria-hidden="true">🪟</span> Windows</strong>
-      <a href="https://github.com/scttfrdmn/prism/releases/latest/download/prism-windows-amd64.zip" class="btn-download">Download</a>
+      <span>Scoop: <code>scoop install prism</code>, or the <code>.msi</code> from Releases.</span>
     </article>
     <article class="download-card">
       <strong><span aria-hidden="true">🐧</span> Linux</strong>
-      <a href="https://github.com/scttfrdmn/prism/releases/latest/download/prism-linux-amd64.tar.gz" class="btn-download">Download</a>
+      <span>Download the release archive and add the binaries to your <code>PATH</code>.</span>
     </article>
   </div>
-  <p class="downloads-note">All releases and changelogs on the <a href="https://github.com/scttfrdmn/prism/releases" target="_blank">GitHub releases page</a>.</p>
+  <p class="downloads-note">Get all builds on the <a href="https://github.com/scttfrdmn/prism/releases/latest" target="_blank">latest release page</a>. See the <a href="user-guides/INSTALLATION/">Installation guide</a> for full instructions.</p>
 </section>
 
 </main>

--- a/docs/user-guides/AWS_SETUP_GUIDE.md
+++ b/docs/user-guides/AWS_SETUP_GUIDE.md
@@ -256,7 +256,7 @@ aws ec2 describe-instances --profile aws --region us-west-2
 **Prism can't find your profile:**
 ```bash
 # Create explicit Prism profile
-prism profiles add research --aws-profile aws --region us-west-2
+prism profiles add personal research --aws-profile aws --region us-west-2
 prism profiles switch research
 
 # Verify it's active
@@ -301,9 +301,9 @@ prism workspace hibernate my-project
 
 ```bash
 # Organize profiles by project/purpose
-prism profiles add personal-research --aws-profile aws --region us-west-2
-prism profiles add team-project --aws-profile work --region us-east-1
-prism profiles add gpu-experiments --aws-profile aws --region us-west-2
+prism profiles add personal personal-research --aws-profile aws --region us-west-2
+prism profiles add personal team-project --aws-profile work --region us-east-1
+prism profiles add personal gpu-experiments --aws-profile aws --region us-west-2
 ```
 
 ## 8. Example Complete Setup

--- a/docs/user-guides/CLI_REFERENCE.md
+++ b/docs/user-guides/CLI_REFERENCE.md
@@ -105,7 +105,8 @@ prism templates info python-ml
 Profiles map a name to an AWS credential profile and region. The daemon uses the active profile for all AWS operations.
 
 ```bash
-prism profiles add                            # Interactive: add a new profile
+prism profiles setup                          # Interactive wizard (recommended)
+prism profiles add personal <name> --aws-profile <p> --region <r>   # Add explicitly
 prism profiles list                           # Show all profiles (active profile marked)
 prism profiles switch <name>                  # Make a profile active
 prism profiles delete <name>                  # Remove a profile

--- a/docs/user-guides/QUICK_START.md
+++ b/docs/user-guides/QUICK_START.md
@@ -23,11 +23,16 @@ Verify:
 prism version
 ```
 
+Other install methods (DMG/MSI, build from source) are in the
+[Installation guide](INSTALLATION.md).
+
 ---
 
 ## 2. Authenticate with AWS
 
-Prism uses your AWS credentials to launch instances in your account.
+Prism runs in **your own AWS account**. You need AWS credentials with permission
+to launch instances — see the [AWS Setup guide](AWS_SETUP_GUIDE.md) for the exact
+IAM policy Prism needs and how to attach it.
 
 **Step 1 — Log in** (requires AWS CLI v2.32+):
 
@@ -37,7 +42,7 @@ aws login
 
 This opens a browser window. Sign in with your IAM user or federated identity. Credentials are cached for up to 12 hours and refresh automatically.
 
-> **No browser?** Use `aws login --remote` for cross-device authentication, or `aws configure` to set up long-term access keys (see [AWS Setup Guide](AWS_SETUP_GUIDE.md)).
+> **No browser?** Use `aws login --remote` for cross-device authentication, or `aws configure` to set up long-term access keys (see [AWS Setup guide](AWS_SETUP_GUIDE.md)).
 
 Verify it works:
 ```bash
@@ -47,10 +52,10 @@ aws sts get-caller-identity
 **Step 2 — Add a Prism profile**:
 
 ```bash
-prism profiles add
+prism profiles setup
 ```
 
-This interactive wizard links a Prism profile to your AWS credentials and default region. You only need to do this once.
+This interactive wizard links a Prism profile to your AWS credentials and default region. You only need to do this once. (Prefer a one-liner? `prism profiles add personal my-profile --aws-profile default --region us-west-2`.)
 
 ---
 

--- a/docs/user-guides/SCHOOL_PILOT_QUICKSTART.md
+++ b/docs/user-guides/SCHOOL_PILOT_QUICKSTART.md
@@ -21,20 +21,17 @@ Prism is an academic research platform that provides pre-configured cloud enviro
 
 ### Step 1: Install Prism
 
-**For IT Administrators (Recommended)**
 ```bash
-# Install via Homebrew (macOS/Linux)
-brew tap scttfrdmn/prism
-brew install prism
+# macOS
+brew install scttfrdmn/tap/prism
 
-# Or download directly
-curl -L https://github.com/scttfrdmn/prism/releases/latest/download/prism-darwin-arm64.tar.gz
+# Windows
+scoop bucket add scttfrdmn https://github.com/scttfrdmn/scoop-bucket
+scoop install prism
 ```
 
-**For Individual Educators**
-- Download from [GitHub Releases](https://github.com/scttfrdmn/prism/releases)
-- Choose your platform: macOS, Linux, or Windows
-- Extract and run - no complex installation required
+See the [Installation guide](INSTALLATION.md) for all platforms and the desktop
+app.
 
 ### Step 2: AWS Account Setup (One-time per School)
 

--- a/docs/user-guides/ZERO_SETUP_GUIDE.md
+++ b/docs/user-guides/ZERO_SETUP_GUIDE.md
@@ -9,16 +9,15 @@ Prism is designed to work **immediately** after installation, with zero configur
 Zero-setup means you can go from installation to running workstation in **one command**:
 
 ```bash
-# Install Prism (see Installation Guide for your platform)
-brew install scttfrdmn/prism   # macOS/Linux
-# or: scoop install prism       # Windows (via Scoop)
-# or: conda install prism       # Any platform via Conda
+# Install Prism (see the Installation guide for all platforms)
+brew install scttfrdmn/tap/prism   # macOS/Linux
+# or: scoop install prism          # Windows
 
 # Launch a workstation - that's it!
-prism workspace launch "Python Machine Learning (Simplified)" my-research
+prism workspace launch python-ml my-research
 ```
 
-For detailed installation instructions, see the main [Installation Guide](../index.md#installation).
+For all install methods, see the [Installation guide](INSTALLATION.md).
 
 **No configuration files. No setup scripts. No manual steps.**
 
@@ -195,13 +194,11 @@ prism workspace launch template my-instance \
 
 ### Issue: "AWS credentials not found"
 
-**Solution:** Configure AWS CLI once:
+**Solution:** Authenticate once (browser-based):
 ```bash
 aws login
-# Enter your Access Key ID
-# Enter your Secret Access Key
-# Enter default region (us-west-2)
-# Enter output format (json)
+# Opens a browser to sign in; caches credentials for ~12h.
+# Prefer long-term keys? Use `aws configure` instead.
 ```
 
 ### Issue: "No default VPC in region"
@@ -233,12 +230,12 @@ While zero-setup works for most users, power users can customize:
 Manage multiple AWS accounts:
 ```bash
 # Add a research account
-prism profiles add research \
+prism profiles add personal research \
   --aws-profile research \
   --region eu-central-1
 
 # Add a personal account  
-prism profiles add personal \
+prism profiles add personal personal \
   --aws-profile personal \
   --region us-west-2
 


### PR DESCRIPTION
## Summary

**Phase 4** of the docs overhaul: make the **Getting Started arc** — Quick Start → Installation → Zero-Setup → AWS Setup → Terminology — read as one coherent, accurate path. `mkdocs build --strict`: 0 warnings.

## Changes

- **QUICK_START** — install section now points to the canonical `INSTALLATION` guide instead of duplicating it; adds an explicit "Prism runs in **your own AWS account** — here's the IAM policy it needs" breadcrumb to AWS Setup; fixes the profile step.
- **The `prism profiles` fix** (real bug across several docs): bare `prism profiles add` only prints help — it's a parent command whose real subcommands are `add personal` / `add invitation`. The interactive wizard is `prism profiles setup`. Corrected in QUICK_START, index.md, CLI_REFERENCE, ZERO_SETUP, and AWS_SETUP (`profiles add <name>` → `profiles add personal <name>`).
- **index.md Downloads** — replaced fabricated per-arch `.tar.gz` asset URLs (releases only ship `.dmg`/`.msi`) with package-manager guidance + links to the releases page and Installation guide.
- **ZERO_SETUP** — dropped fictional `conda install prism`; fixed `scttfrdmn/prism` → `scttfrdmn/tap/prism`; corrected the `aws login` troubleshooting block (browser login, not key entry).
- **SCHOOL_PILOT** — fixed wrong `brew tap` form + fabricated download URL → correct taps + Installation-guide link.

## Verification

`mkdocs build --strict` — 0 warnings. No remaining wrong `brew tap` forms or fabricated release-asset URLs. All profile commands verified against the real v0.36.1 CLI.

## Remaining

Only **Phase 6** (code rationalization) is left: the defined-but-unregistered `security`/`config`/`plugin` CLI commands, the absent `doctor`, and filing 2 feature-gap issues (`templates compile`, `dcv` CLI). Optional.