### PR TITLE
fix(cli): register the built-but-orphaned `prism security` command (Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`prism security` command exposed.** The fully-built security & compliance
+  command tree (`security status|health|dashboard|correlations|keychain|config`
+  and `security compliance validate|report|scp|frameworks`) was implemented and
+  had matching daemon endpoints (`/api/v1/security/*`) but was never registered
+  on the root command — so it was unreachable. It is now wired up and documented
+  in the CLI reference.
 - **Parameter sweeps: launch one instance per parameter set (spawn adoption).** New
   `prism workspace launch <template> <name> --param-file <file.json|yaml|csv>`
   launches a sweep — one workspace named `<name>-0`..`<name>-(N-1)` per parameter

--- a/docs/user-guides/CLI_REFERENCE.md
+++ b/docs/user-guides/CLI_REFERENCE.md
@@ -200,9 +200,24 @@ prism admin daemon start                     # Start explicitly (usually not nee
 prism admin daemon stop                      # Stop the daemon
 
 prism admin policy list                      # List access control policies
-prism admin quota show                       # Check AWS service quotas
+prism admin quota show --instance-type t3.large   # Check AWS quota for a type
 prism admin aws-health                       # AWS service health status
 prism admin rightsizing analyze              # Instance sizing recommendations
+```
+
+---
+
+## Security & compliance
+
+```bash
+prism security status                        # Security monitoring / audit status
+prism security health                        # Run a security health check
+prism security dashboard                     # Threat analysis and recommendations
+prism security keychain                      # Keychain provider diagnostics
+
+prism security compliance frameworks         # List supported frameworks
+prism security compliance validate nist-800-171   # Validate against a framework
+prism security compliance report hipaa       # Generate a compliance report
 ```
 
 ---
@@ -211,7 +226,7 @@ prism admin rightsizing analyze              # Instance sizing recommendations
 
 ```bash
 prism gui                                    # Launch the desktop GUI
-prism init                                   # First-run wizard (AWS setup, profile creation)
+prism init                                   # Guided first launch (validates AWS creds, launches a workspace)
 prism version                                # Show current version
 prism templates                              # Alias: same as prism templates list
 ```

--- a/internal/cli/root_command.go
+++ b/internal/cli/root_command.go
@@ -508,6 +508,11 @@ func (r *CommandFactoryRegistry) RegisterAllCommands(rootCmd *cobra.Command) {
 	// Slack/Teams bot integration (#607)
 	botCobra := NewBotCobraCommands(r.app)
 	rootCmd.AddCommand(botCobra.CreateBotCommand())
+
+	// Security & compliance (status/health/dashboard/keychain/config + AWS
+	// compliance validate/report/scp). The backend /api/v1/security/* endpoints
+	// already exist; this wires the fully-built command tree to the root.
+	rootCmd.AddCommand(r.app.SecurityCommand())
 }
 
 func (r *CommandFactoryRegistry) createSnapshotCommand() *cobra.Command {


### PR DESCRIPTION
## Summary

**Phase 6** (code rationalization) of the docs+code overhaul. The documentation audit flagged several CLI commands as "referenced but not working." Investigating each:

### The real bug: `prism security` was built but never wired up

`internal/cli/security.go` contains a **complete, 1030-line** security & compliance command tree — `security status | health | dashboard | correlations | keychain | config` plus `security compliance validate | report | scp | frameworks` — with **matching daemon endpoints** already registered (`/api/v1/security/*` in `server.go`). But `SecurityCommand()` was never added to the root command, so the whole feature was unreachable from the CLI.

**Fix:** one registration line in `root_command.go` + a Security section in `CLI_REFERENCE.md` + CHANGELOG entry.

### The other flagged commands — no code change needed

- **`config` / `plugin`** — no orphaned top-level definitions. The only `config` is the now-registered `security config` (plus legit `daemon config` / `workshop config` subcommands). `plugins.md` documents the plugin *system*, not a `prism plugin` command.
- **`doctor`** — does not exist in code; its doc references were already corrected in the Phase 2 correctness pass.

### Feature-gap issues filed

Two genuinely-missing-but-once-documented features, now tracked rather than silently dropped:
- #683 — `prism templates compile` (template → AMI)
- #684 — `prism dcv` (DCV desktop session CLI)

### Also

- `CLI_REFERENCE`: corrected the `prism init` description (validates creds + launches a workspace; does **not** create profiles) and the `admin quota show` example (needs `--instance-type`).

## Verification

`go build ./...`, `go vet`, `go test ./internal/cli/`, `gofmt`, and `mkdocs build --strict` all clean. `prism security --help` now lists the full tree.

---

This is the final phase of the documentation + code overhaul. Net result across all phases: **docs 266 → 54**, every published command verified against the real CLI, IAM policy corrected, a spore.host-style landing page, and this orphaned command reconnected.