### PR TITLE
docs(landing): add S3+CloudFront deploy script (spore.host pattern)

### DIFF
--- a/landing/README.md
+++ b/landing/README.md
@@ -22,9 +22,28 @@ python3 -m http.server -d landing 8000   # then visit http://localhost:8000
 
 ## Deploying to prismcloud.host
 
-The page is a single static file, so it works on any static host (Netlify,
-Cloudflare Pages, S3 + CloudFront, GitHub Pages, etc.). Point the apex domain at
-your chosen host and upload `landing/`.
+Prism follows the **same AWS pattern spore.host uses** (S3 static website +
+CloudFront + ACM + Route 53), run from the `prism-infra` AWS profile:
+
+```bash
+AWS_PROFILE=prism-infra ./landing/deploy.sh
+```
+
+`deploy.sh` creates/uses the `prismcloud-host-website` S3 bucket, enables static
+hosting, sets a public-read policy, uploads `landing/`, and (once
+`PRISM_CLOUDFRONT_ID` is set) invalidates the CloudFront cache. It mirrors
+`~/src/spore-host/spore-host/web/deploy.sh`.
+
+**One-time infra setup** (see the deploy tracking issue for exact commands):
+1. ACM certificate for `prismcloud.host` in **us-east-1**.
+2. CloudFront distribution: origin = the S3 website endpoint, alternate domain
+   name = `prismcloud.host`, viewer policy = redirect-HTTP-to-HTTPS, cert from
+   step 1. Note its distribution ID → set `PRISM_CLOUDFRONT_ID`.
+3. Route 53 apex A/ALIAS record `prismcloud.host` → the CloudFront distribution.
+
+Docs (`docs.prismcloud.host`) deploy separately — the existing MkDocs `gh-pages`
+site, retargeted to the `docs.` subdomain (or its own S3+CloudFront like
+`docs.spore.host`). See the tracking issue for the coordinated cutover.
 
 ### Domain topology
 

--- a/landing/deploy.sh
+++ b/landing/deploy.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Deploy the Prism landing page to S3 + CloudFront.
+#
+# Mirrors the spore.host web/deploy.sh pattern (S3 static website + CloudFront +
+# Route53 alias) so prismcloud.host follows the same infra shape as spore.host.
+#
+# One-time setup (see landing/README.md and the tracking issue): create the S3
+# bucket, an ACM cert for prismcloud.host in us-east-1, a CloudFront distribution
+# with that cert + the apex as an alternate domain name, and a Route53 A/ALIAS
+# record for the apex → CloudFront. Then set DISTRIBUTION_ID below (or via env).
+
+set -e
+
+BUCKET_NAME="${PRISM_WEBSITE_BUCKET:-prismcloud-host-website}"
+REGION="us-east-1"
+DOMAIN="prismcloud.host"
+AWS_PROFILE="${AWS_PROFILE:-prism-infra}"        # follow spore-host-infra convention
+DISTRIBUTION_ID="${PRISM_CLOUDFRONT_ID:-}"       # set after the distribution exists
+
+GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+
+echo -e "${BLUE}Deploying Prism landing page → ${DOMAIN}${NC}"
+
+command -v aws >/dev/null 2>&1 || { echo -e "${RED}AWS CLI not installed${NC}"; exit 1; }
+
+echo -e "${BLUE}→${NC} Checking AWS credentials (profile: ${AWS_PROFILE})..."
+aws sts get-caller-identity --profile "$AWS_PROFILE" >/dev/null 2>&1 || {
+  echo -e "${RED}AWS credentials not configured for profile $AWS_PROFILE${NC}"; exit 1; }
+echo -e "${GREEN}✓${NC} credentials OK"
+
+# S3 bucket (create if missing)
+if ! aws s3 ls "s3://$BUCKET_NAME" --profile "$AWS_PROFILE" >/dev/null 2>&1; then
+  echo -e "${YELLOW}!${NC} creating bucket $BUCKET_NAME"
+  aws s3 mb "s3://$BUCKET_NAME" --region "$REGION" --profile "$AWS_PROFILE"
+fi
+
+aws s3 website "s3://$BUCKET_NAME" \
+  --index-document index.html --error-document index.html \
+  --profile "$AWS_PROFILE"
+
+cat > /tmp/prism-bucket-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "PublicReadGetObject",
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::$BUCKET_NAME/*"
+  }]
+}
+EOF
+aws s3api put-bucket-policy --bucket "$BUCKET_NAME" \
+  --policy file:///tmp/prism-bucket-policy.json --profile "$AWS_PROFILE"
+rm -f /tmp/prism-bucket-policy.json
+
+# Upload the landing page (this directory), excluding tooling
+echo -e "${BLUE}→${NC} uploading landing files..."
+aws s3 sync "$(dirname "$0")" "s3://$BUCKET_NAME/" \
+  --delete \
+  --exclude ".DS_Store" --exclude "*.sh" --exclude "README.md" \
+  --cache-control "max-age=3600" \
+  --profile "$AWS_PROFILE"
+echo -e "${GREEN}✓${NC} uploaded"
+
+if [ -n "$DISTRIBUTION_ID" ]; then
+  echo -e "${BLUE}→${NC} invalidating CloudFront ($DISTRIBUTION_ID)..."
+  aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" \
+    --paths "/*" --profile "$AWS_PROFILE" --query 'Invalidation.Id' --output text
+else
+  echo -e "${YELLOW}!${NC} PRISM_CLOUDFRONT_ID not set — skipped cache invalidation."
+  echo "  Create the CloudFront distribution + Route53 alias once, then set it."
+fi
+
+echo -e "${GREEN}✓ done${NC}  (S3 website: http://$BUCKET_NAME.s3-website-$REGION.amazonaws.com)"


### PR DESCRIPTION
## Summary

Adds `landing/deploy.sh` + deploy runbook so the landing page can be published to **prismcloud.host** following the **same AWS pattern spore.host uses** (S3 static website + CloudFront + ACM + Route 53, run from a `prism-infra` profile).

Mirrors `~/src/spore-host/spore-host/web/deploy.sh`:
- creates/uses the `prismcloud-host-website` S3 bucket, enables static hosting, sets a public-read policy
- `aws s3 sync`'s `landing/` up (excluding tooling files)
- invalidates CloudFront when `PRISM_CLOUDFRONT_ID` is set

`landing/README.md` now documents the one-time ACM/CloudFront/Route 53 setup.

**No AWS infra is created by this PR** — it's the tooling + runbook. The full coordinated cutover (apex → landing, docs → `docs.prismcloud.host`, DNS records, and the deferred `docs/CNAME`/`site_url` flip) is tracked in #686.

## Related
- #686 — deploy landing + split domain (the cutover checklist)