### PR TITLE
fix(gui): tidy prism-gui module to unbreak `make build`

### DIFF
--- a/cmd/prism-gui/go.mod
+++ b/cmd/prism-gui/go.mod
@@ -22,9 +22,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/artifact v1.18.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.66.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.313.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/efs v1.43.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.67.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 // indirect

--- a/cmd/prism-gui/go.sum
+++ b/cmd/prism-gui/go.sum
@@ -20,12 +20,12 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31/go.mod h1:7PuV1yl5e2xnUbm+RqvVg5i2iBM8EyijZNoI9wsOoOc=
 github.com/aws/aws-sdk-go-v2/service/artifact v1.18.0 h1:kV7hX+Q6pdpaHdssv8razttXS61+axv60LvoM/Cp5yM=
 github.com/aws/aws-sdk-go-v2/service/artifact v1.18.0/go.mod h1:g5J2L9MHrY2H3cn8UNN8UHDvwu0SmEMHD2p3nWS5eag=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0 h1:wvV1Dd0OGEMYsLkDrFVxk0c/hOhdiXCuBLTaeHsW/Vc=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0/go.mod h1:lipiF9DI3EmTTkEn2sgLug3iEO1dXM50FDFooey6vYU=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0 h1:08KUBEtOMByhBOjXsbWYGx4ECPCatdJSMKWP8zMpm1g=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0/go.mod h1:lipiF9DI3EmTTkEn2sgLug3iEO1dXM50FDFooey6vYU=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.66.0 h1:T3jxS+DOPA6f4XkTRuHRjuna0Ys2UtYLjUSyGQAvX84=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.66.0/go.mod h1:VxTOTlVMfxNZbg2L7dBXv0gdmR73HK7T5yrKISfZTz4=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.313.0 h1:IkVPFiv4v1tSMfhtzxeO/qYa47lJhRuBHFC6g3vHJdo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.313.0/go.mod h1:eoF0SIRbTgKWnTcTPYckiURPba/7ilfEkvwL4V1iHK4=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0 h1:LlxNun/oe5B2XMff8Mkh/3bJeHl1K7Fod+rMYtjagw4=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0/go.mod h1:eoF0SIRbTgKWnTcTPYckiURPba/7ilfEkvwL4V1iHK4=
 github.com/aws/aws-sdk-go-v2/service/efs v1.43.0 h1:xjRmCnQn7Yo+hgMzrEShD2d6T7IA/+Lo+iot5DIDa9M=
 github.com/aws/aws-sdk-go-v2/service/efs v1.43.0/go.mod h1:yXgsIt7Lw+d8V7khvXEXvIoziyW65xfJhr7Fb9U8Kao=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.67.0 h1:9BskQP6sK4psaXnPw1k+FLzW6o8sCM/kQpS/VRLg/So=


### PR DESCRIPTION
## What

`go mod tidy` in `cmd/prism-gui`. Two version lines in `go.mod`, four in `go.sum`. No source changes.

## Why

`make build` currently fails for anyone with the Wails CLI installed:

```
task: [build] go build -o ../../bin/prism-gui .
go: updates to go.mod needed; to update it:
	go mod tidy
  ERROR   task: Failed to run task "build": exit status 1
```

`cmd/prism-gui` is a separate Go module that consumes the root module through `replace github.com/scttfrdmn/prism => ../../`. Go's pruned module graph requires it to record the indirect versions the root module needs. When #673 bumped `aws-sdk-go-v2/service/ec2` 1.313.0 -> 1.316.0 and `service/cloudwatch` 1.62.0 -> 1.63.0 in the root `go.mod`, this module's `go.mod` kept pinning the old versions and the GUI stopped building.

## This is the second occurrence

9aede12c ("chore: go mod tidy on prism-gui module") was the same fix in April. The drift is structural, not accidental: Dependabot only watches `directory: "/"`, and no CI job builds the GUI, so nothing catches it until someone runs `make build` locally. A follow-up PR adds a `go mod tidy -diff` step to CI so the next dependency bump fails its own PR instead of everyone else's build.

## Verification

- `cd cmd/prism-gui && go mod tidy -diff` -- clean
- `make build` -- produces `bin/prism`, `bin/prismd`, `bin/prism-gui`
- `go build ./...` and `go test ./...` at repo root -- pass
