### PR TITLE
ci(gui): catch prism-gui module drift, stop `make build` faking success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,21 @@ jobs:
             exit 1
           fi
 
+      # cmd/prism-gui is a separate module that consumes the root module via
+      # `replace github.com/scttfrdmn/prism => ../../`. Go's pruned module graph
+      # makes it record the root module's indirect requirements, so bumping a
+      # dependency in the root go.mod leaves it stale and breaks `make build` --
+      # while every job here stays green, because none of them build the GUI.
+      # `go mod tidy -diff` reports the drift without writing anything, and
+      # needs no wails3, no npm, and no frontend build.
+      - name: Check prism-gui module is tidy
+        working-directory: cmd/prism-gui
+        run: |
+          if ! go mod tidy -diff; then
+            echo "::error::cmd/prism-gui/go.mod is out of sync with the root module. Fix with: cd cmd/prism-gui && go mod tidy"
+            exit 1
+          fi
+
       - name: Build CLI
         run: go build -o bin/prism ./cmd/prism
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 # Build flags
 LDFLAGS := -ldflags "-X github.com/scttfrdmn/prism/pkg/version.Version=$(VERSION) -X github.com/scttfrdmn/prism/pkg/version.BuildDate=$(BUILD_TIME) -X github.com/scttfrdmn/prism/pkg/version.GitCommit=$(GIT_COMMIT)"
 
+# Resolve the wails3 binary once: PATH first, then the default `go install`
+# location. Resolving up front replaces the
+# `command -v wails3 && wails3 task build || $$HOME/go/bin/wails3 task build`
+# idiom, where the `||` cannot tell "wails3 is not on PATH" from "the build
+# failed" -- so on a machine that has wails3 on PATH, a failing build silently
+# ran a second time and reported the second attempt's status.
+WAILS3 := $(shell command -v wails3 2>/dev/null || echo "$$HOME/go/bin/wails3")
+
 # Check if VERSION matches pkg/version/version.go
 .PHONY: check-version
 check-version:
@@ -30,7 +38,11 @@ build-for-tests: clean
 	@echo "🔨 Force rebuilding all binaries (daemon, CLI, GUI)..."
 	@go build -a $(LDFLAGS) -o bin/prismd ./cmd/prismd
 	@go build -a $(LDFLAGS) -o bin/prism ./cmd/prism
-	@cd cmd/prism-gui && (command -v wails3 >/dev/null 2>&1 && wails3 task build || $$HOME/go/bin/wails3 task build) || echo "⚠️ GUI build skipped"
+	@if [ ! -x "$(WAILS3)" ]; then \
+		echo "⚠️  Wails v3 CLI not found - GUI build skipped"; \
+	elif ! (cd cmd/prism-gui && "$(WAILS3)" task build); then \
+		echo "⚠️  GUI build FAILED - continuing with daemon and CLI only"; \
+	fi
 	@echo "✅ Fresh build complete"
 
 # Build daemon binary
@@ -49,24 +61,35 @@ build-cli:
 .PHONY: build-gui
 build-gui:
 	@echo "Building Prism GUI (Wails 3.x)..."
-	@if ! command -v wails3 >/dev/null 2>&1 && ! [ -f "$$HOME/go/bin/wails3" ]; then \
+	@if [ ! -x "$(WAILS3)" ]; then \
 		echo "❌ Wails v3 CLI not found. Install with: go install github.com/wailsapp/wails/v3/cmd/wails3@latest"; \
 		exit 1; \
 	fi
-	@cd cmd/prism-gui && (command -v wails3 >/dev/null 2>&1 && wails3 task build || $$HOME/go/bin/wails3 task build)
+	@cd cmd/prism-gui && "$(WAILS3)" task build
 
-# Build GUI binary (optional - won't fail if prerequisites missing)
+# Build GUI binary (optional - a missing Wails CLI is skipped, not an error)
+#
+# "Optional" means the *prerequisite* is optional. A GUI build that runs and
+# fails is a real failure and stops `make build`: scripts/build-dmg.sh calls
+# `make build` on the release path and only verifies that bin/prism and
+# bin/prismd exist, so a GUI build that failed silently would package whatever
+# stale bin/prism-gui happened to be left over from an earlier build.
 .PHONY: build-gui-optional
 build-gui-optional:
 	@echo "🎨 Building Prism GUI (optional)..."
-	@if command -v wails3 >/dev/null 2>&1 || [ -f "$$HOME/go/bin/wails3" ]; then \
-		echo "✅ Wails CLI found, building GUI..."; \
-		cd cmd/prism-gui && (command -v wails3 >/dev/null 2>&1 && wails3 task build || $$HOME/go/bin/wails3 task build); \
-		echo "✅ GUI built successfully"; \
-	else \
+	@if [ ! -x "$(WAILS3)" ]; then \
 		echo "⚠️  Wails v3 CLI not found - GUI build skipped"; \
 		echo "   To include GUI: go install github.com/wailsapp/wails/v3/cmd/wails3@latest"; \
 		echo "   GUI can be built separately with: make build-gui"; \
+		exit 0; \
+	fi; \
+	echo "✅ Wails CLI found, building GUI..."; \
+	if (cd cmd/prism-gui && "$(WAILS3)" task build); then \
+		echo "✅ GUI built successfully"; \
+	else \
+		echo "❌ GUI build FAILED (see the wails3 output above)"; \
+		echo "   If the error mentions go.mod, run: cd cmd/prism-gui && go mod tidy"; \
+		exit 1; \
 	fi
 
 # Force GUI build (for development/testing only)

--- a/cmd/prism-gui/go.mod
+++ b/cmd/prism-gui/go.mod
@@ -22,9 +22,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/artifact v1.18.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.66.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.313.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/efs v1.43.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.67.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 // indirect

--- a/cmd/prism-gui/go.sum
+++ b/cmd/prism-gui/go.sum
@@ -20,12 +20,12 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31/go.mod h1:7PuV1yl5e2xnUbm+RqvVg5i2iBM8EyijZNoI9wsOoOc=
 github.com/aws/aws-sdk-go-v2/service/artifact v1.18.0 h1:kV7hX+Q6pdpaHdssv8razttXS61+axv60LvoM/Cp5yM=
 github.com/aws/aws-sdk-go-v2/service/artifact v1.18.0/go.mod h1:g5J2L9MHrY2H3cn8UNN8UHDvwu0SmEMHD2p3nWS5eag=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0 h1:wvV1Dd0OGEMYsLkDrFVxk0c/hOhdiXCuBLTaeHsW/Vc=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0/go.mod h1:lipiF9DI3EmTTkEn2sgLug3iEO1dXM50FDFooey6vYU=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0 h1:08KUBEtOMByhBOjXsbWYGx4ECPCatdJSMKWP8zMpm1g=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0/go.mod h1:lipiF9DI3EmTTkEn2sgLug3iEO1dXM50FDFooey6vYU=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.66.0 h1:T3jxS+DOPA6f4XkTRuHRjuna0Ys2UtYLjUSyGQAvX84=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.66.0/go.mod h1:VxTOTlVMfxNZbg2L7dBXv0gdmR73HK7T5yrKISfZTz4=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.313.0 h1:IkVPFiv4v1tSMfhtzxeO/qYa47lJhRuBHFC6g3vHJdo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.313.0/go.mod h1:eoF0SIRbTgKWnTcTPYckiURPba/7ilfEkvwL4V1iHK4=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0 h1:LlxNun/oe5B2XMff8Mkh/3bJeHl1K7Fod+rMYtjagw4=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0/go.mod h1:eoF0SIRbTgKWnTcTPYckiURPba/7ilfEkvwL4V1iHK4=
 github.com/aws/aws-sdk-go-v2/service/efs v1.43.0 h1:xjRmCnQn7Yo+hgMzrEShD2d6T7IA/+Lo+iot5DIDa9M=
 github.com/aws/aws-sdk-go-v2/service/efs v1.43.0/go.mod h1:yXgsIt7Lw+d8V7khvXEXvIoziyW65xfJhr7Fb9U8Kao=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.67.0 h1:9BskQP6sK4psaXnPw1k+FLzW6o8sCM/kQpS/VRLg/So=


### PR DESCRIPTION
> **Stacked on #695 -- please merge that first.** This branch carries #695's `go mod tidy` as its first commit, because the CI check added here fails on current `main`: `main` is exactly the drifted state #695 fixes. **Review only the second commit.**
>
> Since this repo squash-merges, #695 will land as a new commit and my copy of it will not become an ancestor of `main`. I will rebase this branch onto `main` once #695 is in, so the `go.mod`/`go.sum` change drops out and this PR reduces to the CI and Makefile changes. Ping me and I will do it, or feel free to merge #695 and I will notice.

#695 fixes the symptom. This fixes the two reasons nobody noticed.

## 1. CI never builds the GUI

`cmd/prism-gui` is a separate module consuming the root module via `replace => ../../`, so Go's pruned module graph makes it record the root module's indirect requirements. A dependency bump to the root `go.mod` leaves it stale and breaks `make build` -- while every CI job stays green, because `lint-and-build` only builds `prism` and `prismd`.

Adds a `go mod tidy -diff` step to `lint-and-build`. It reports drift without writing anything and needs no wails3, no npm, and no frontend build -- verified by running it with `cmd/prism-gui/frontend/dist` moved aside, where it still exits 1 on the drifted `go.mod` and 0 on the tidy one.

Building the GUI in CI would also catch this, but needs the Wails toolchain and a frontend build. This check costs one `go` invocation.

## 2. `make build` reported success after the GUI build failed

`build-gui-optional` ran the build, ignored its exit status, and printed `GUI built successfully` regardless -- the `echo` followed a `;`, not a `&&`. The real error scrolled past above that line and `make build` exited 0. That is what made #695 hard to diagnose: the build says it worked.

A missing Wails CLI is still skipped -- that is the "optional" part, and contributors without it are unaffected. A GUI build that runs and fails now stops `make build`. That last part is a behavior change, so the reasoning: `scripts/build-dmg.sh` calls `make build` on the release path (line 150) and then verifies only that `bin/prism` and `bin/prismd` exist. A silently failing GUI build there packages whatever stale `bin/prism-gui` an earlier build left behind. On my machine the three binaries were dated three months apart. If you would rather `make build` stay green and only print the error honestly, deleting the `exit 1` does that and still fixes the diagnosis problem.

## 3. The wails3 fallback masked failures

`command -v wails3 >/dev/null && wails3 task build || $HOME/go/bin/wails3 task build` cannot tell "wails3 is not on PATH" from "the build failed". On a machine with wails3 on PATH, a failing build ran a second time through the `$HOME` path and reported the second attempt's status. Replaced with a single `$(WAILS3)` resolved once at parse time, used by all three call sites.

## Verification

| case | expected | result |
|---|---|---|
| tidy tree, wails3 present | all three binaries | pass |
| drifted `go.mod` | `make build` exits nonzero, names `go mod tidy` | exit 2 |
| wails3 absent, `build-gui-optional` | skip, exit 0 | pass |
| wails3 absent, `build-gui` | error, exit 1 | pass |
| failing wails3 | invoked exactly once | 1 invocation (was 2) |
| `go mod tidy -diff` with no `frontend/dist` | still detects drift | exit 1 |
| `make version` | no stray output from the new `$(shell)` | 0.135s, clean |

`go build ./...` and `go test ./...` pass. `gofmt -l` clean.
