### PR TITLE
fix(lint): unbreak the goimports and misspell stages of `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,11 @@ lint:
 	@gocyclo -over 15 . || true
 	@echo "  • Running misspell (spelling errors)..."
 	@command -v misspell >/dev/null 2>&1 || { echo "misspell not found. Install with: go install github.com/client9/misspell/cmd/misspell@latest"; exit 1; }
-	@misspell -error -i node_modules .
+	@# misspell's -i takes words to ignore, not paths, so `-i node_modules` never
+	@# excluded the directory and every run drowned in vendored JS. Feeding it the
+	@# tracked file list excludes node_modules (gitignored) and everything else we
+	@# do not own. `comandos` is correct Spanish in packaging/rpm/prism.spec.
+	@git ls-files -z | xargs -0 misspell -error -i comandos
 	@echo "  • Running staticcheck (static analysis)..."
 	@command -v staticcheck >/dev/null 2>&1 || { echo "staticcheck not found. Install with: go install honnef.co/go/tools/cmd/staticcheck@latest"; exit 1; }
 	@staticcheck ./...

--- a/pkg/aws/retry.go
+++ b/pkg/aws/retry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+
 	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- retry jitter, not cryptography.
 	"math/rand" //nolint:gosec // math/rand used for retry jitter, not cryptography
 	"net"

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+
 	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- retry jitter, not cryptography.
 	"math/rand" //nolint:gosec // math/rand used for retry jitter, not cryptography
 	"strings"


### PR DESCRIPTION
`CLAUDE.md` lists `make lint` as a mandatory release gate, but on a clean checkout of `main` it exits early. Two independent reasons, both fixed here. Independent of #695/#696 -- different files, no conflict.

## 1. goimports (stage 2 of 8)

`pkg/aws/retry.go` and `pkg/retry/retry.go` both want a blank line before the `// nosemgrep:` comment that precedes `"math/rand"`. Two blank lines total.

The `// nosemgrep:` annotation and the inline `//nolint:gosec` both stay attached to the `"math/rand"` line, so the Semgrep suppressions added in #670 are unaffected:

```go
 	"math"
+
 	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- retry jitter, not cryptography.
 	"math/rand" //nolint:gosec // math/rand used for retry jitter, not cryptography
```

CI cannot confirm that on this PR -- the Security Scan job fails at `npm audit` before reaching the Semgrep step, so Semgrep is skipped rather than run (see the note at the bottom). So I ran it locally with the same ruleset this repo uses, `p/golang`, against both versions of both files, plus a positive control with the `nosemgrep` line stripped to prove the rule is actually active:

| version | total findings | `math_random` hits |
|---|---|---|
| control -- `nosemgrep` line removed | 1 | **1** |
| baseline -- `main` | 0 | 0 |
| patched -- this branch | 0 | 0 |

The control firing is what makes the two zeros meaningful: the rule is live, and the suppression survives the reformat.

## 2. misspell (stage 5 of 8)

`misspell -error -i node_modules .` reported hundreds of hits inside `cmd/prism-gui/frontend/node_modules` -- `xterm.js.map`, `typescript.js`, `recharts`, `zod`.

misspell's `-i` takes a comma-separated list of *corrections to ignore*, not a path to skip, so `node_modules` was never excluded and was rescanned on every run. Switched to the tracked file list, which excludes `node_modules` because it is gitignored.

That left exactly one hit in a file this repo owns:

```
packaging/rpm/prism.spec:54:38: "comandos" is a misspelling of "commandos"
```

Line 54 is the Spanish description -- "Prism es una herramienta de linea de comandos" -- where `comandos` is the correct word. Suppressed with `-i comandos`, which is what the flag is actually for.

## Verification

- goimports and gofmt: clean and idempotent on both files
- `go vet ./...`: passes
- misspell over tracked files: exits 0, and still catches a planted `recieve`
- `go build ./...` and `go test ./...`: pass

## What this does *not* fix

`make lint` still does not pass. I installed the remaining tools and ran the later stages against `main`:

- `staticcheck ./...` -- about 25 issues (deprecated `strings.Title`, ~15 unused functions, `SA1029` string context keys, `S1012` `time.Now().Sub`)
- `golangci-lint run` -- 419 issues, and that is with most linters capped at 50 reported each, so the real count is higher

So `CLAUDE.md`'s "make lint -- zero issues" gate is not currently reachable, and that is a much larger cleanup than this PR. What this PR buys is that the target now *gets to* those stages: `misspell -error` aborted the run at stage 5, so `staticcheck` and `golangci-lint` never executed and their output was invisible. Fixing the two broken stages turns `make lint` from "fails on vendored JavaScript" into "reports real findings about our own code."

Happy to close this if you would rather fix the whole gate in one pass.

## Unrelated: the red Security Scan

The failing check on this PR is not from these changes. `npm audit` reports 2 pre-existing high-severity advisories in frontend transitive deps (`brace-expansion`, `postcss`), and it fails before Trivy and Semgrep run. The scheduled Security Scan on `main` has been failing the same way since between 2026-07-20 and 2026-07-27 ([run 30800623335](https://github.com/scttfrdmn/prism/actions/runs/30800623335)). Happy to send a separate PR for it if useful.
